### PR TITLE
Add Headers to be Sent With Server Responses

### DIFF
--- a/src/main/java/ClientThread.java
+++ b/src/main/java/ClientThread.java
@@ -27,8 +27,9 @@ public class ClientThread implements Runnable {
       
       Request request = parseRequest(requestString);
       Response response = this.router.getResponse(request);
-  
-      out.print(response.toString());
+      String formattedResponse = new ResponseFormatter(response).formatResponse();
+
+      out.print(formattedResponse);
 
       closeConnection();
 

--- a/src/main/java/DataStore/DataStore.java
+++ b/src/main/java/DataStore/DataStore.java
@@ -3,5 +3,6 @@ public interface DataStore {
   public String listContent();
   public Boolean existsInStore(String uri);
   public String read(String uri);
+  public String getFileType(String uri);
 
 }

--- a/src/main/java/DataStore/Directory.java
+++ b/src/main/java/DataStore/Directory.java
@@ -50,25 +50,6 @@ public class Directory implements DataStore {
  
     return content; 
   }
-  
-  private String[] getContentsOfDirectory() {
-    File directory = new File(this.directoryPath);
-    return directory.list();
-  }
-
-  private String stringifyContentsOfDirectory(String[] fileNames) {
-    String content = "";
-    
-    if (fileNames.length == 0) {
-      return "Empty directory!";
-    }
-    
-    for (String fileName : fileNames) {
-      content += fileName + "\n";
-    }
-    
-    return content;
-  }
 
   public String getFileType(String uri) {
     String filePath = this.directoryPath + uri;
@@ -99,4 +80,5 @@ public class Directory implements DataStore {
     
     return content;
   }
+  
 }

--- a/src/main/java/DataStore/Directory.java
+++ b/src/main/java/DataStore/Directory.java
@@ -1,9 +1,17 @@
 import java.io.BufferedReader; 
 import java.io.File;
 import java.io.FileReader; 
-import java.io.IOException; 
+import java.io.IOException;
+
+import java.util.Map;
 
 public class Directory implements DataStore {
+  private static final String DEFAULT_FILE_TYPE = "application/octet-stream";
+  private static final Map<String, String> MIME_TYPES = Map.ofEntries(
+      Map.entry("html", "text/html"),
+      Map.entry("txt", "text/plain")
+  );
+  
   private File directory;
   private String directoryPath;
 
@@ -61,4 +69,15 @@ public class Directory implements DataStore {
     
     return content;
   }
+
+  public String getFileType(String uri) {
+    String filePath = this.directoryPath + uri;
+    String extension = getExtension(filePath);
+    return MIME_TYPES.getOrDefault(extension, DEFAULT_FILE_TYPE);
+  }
+
+  private String getExtension(String filePath) {
+    return filePath.split("\\.")[1];
+  }
+  
 }

--- a/src/main/java/DataStore/Directory.java
+++ b/src/main/java/DataStore/Directory.java
@@ -80,4 +80,23 @@ public class Directory implements DataStore {
     return filePath.split("\\.")[1];
   }
   
+  
+  private String[] getContentsOfDirectory() {
+    File directory = new File(this.directoryPath);
+    return directory.list();
+  }
+
+  private String stringifyContentsOfDirectory(String[] fileNames) {
+    String content = "";
+    
+    if (fileNames.length == 0) {
+      return "Empty directory!";
+    }
+    
+    for (String fileName : fileNames) {
+      content += fileName + "\n";
+    }
+    
+    return content;
+  }
 }

--- a/src/main/java/Handler/EchoHandler.java
+++ b/src/main/java/Handler/EchoHandler.java
@@ -1,3 +1,4 @@
+import java.io.UnsupportedEncodingException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -12,13 +13,21 @@ public class EchoHandler implements Handler {
     String messageBody = "";
     switch (method) {
       case "GET": 
-        return new Response.Builder(HttpStatusCode.OK)
-                           .messageBody(createMessageBody())
-                           .build();
+        return buildGETResponse();
       default: 
         return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED)
                            .build();
     }
+  }
+
+  private Response buildGETResponse() {
+    String messageBody = createMessageBody();
+    int contentLength = ResponseHeader.determineContentLength(messageBody);
+    return new Response.Builder(HttpStatusCode.OK)
+                       .contentType("text/plain")
+                       .contentLength(contentLength)
+                       .messageBody(messageBody)
+                       .build();
   }
 
   private String createMessageBody() {
@@ -29,4 +38,5 @@ public class EchoHandler implements Handler {
     DateFormat dateFormat = new SimpleDateFormat(this.timeFormat);
     return dateFormat.format(new Date());
   }
+  
 }

--- a/src/main/java/Handler/EchoHandler.java
+++ b/src/main/java/Handler/EchoHandler.java
@@ -13,14 +13,14 @@ public class EchoHandler implements Handler {
     String messageBody = "";
     switch (method) {
       case "GET": 
-        return buildGETResponse();
+        return buildGetResponse();
       default: 
         return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED)
                            .build();
     }
   }
 
-  private Response buildGETResponse() {
+  private Response buildGetResponse() {
     String messageBody = createMessageBody();
     int contentLength = ResponseHeader.determineContentLength(messageBody);
     return new Response.Builder(HttpStatusCode.OK)

--- a/src/main/java/Handler/FileHandler.java
+++ b/src/main/java/Handler/FileHandler.java
@@ -1,6 +1,6 @@
 import java.io.UnsupportedEncodingException;
 
- public class FileHandler implements Handler {
+ public class FileHandler implements Handler {   
   private DataStore store;
   private String uri;
   
@@ -13,48 +13,39 @@ import java.io.UnsupportedEncodingException;
      
     switch (request.getMethod()) { 
       case "GET":  
-        return buildGETResponse(); 
+        return buildGetResponse(); 
       default:  
         return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED) 
                            .build(); 
     } 
   }
 
-  private Response buildGETResponse() { 
+  private Response buildGetResponse() {
     int statusCode = determineStatusCode();
-    String contentType = determineContentType();
-    String messageBody = createMessageBody(statusCode);
+    String messageBody = createMessageBody();
     int contentLength = ResponseHeader.determineContentLength(messageBody);
-     
-    return new Response.Builder(statusCode) 
-                       .contentType(contentType)
-                       .contentLength(contentLength)
-                       .messageBody(messageBody) 
-                       .build(); 
-  } 
+    String contentType = determineContentType();
+    return new Response.Builder(statusCode)
+                   .messageBody(messageBody)
+                   .contentLength(contentLength)
+                   .contentType(contentType)
+                   .build();
+  }
 
   private int determineStatusCode() {
     return this.store.existsInStore(this.uri) ? HttpStatusCode.OK : HttpStatusCode.NOT_FOUND;
   }
 
+  private String createMessageBody() {
+    return this.store.existsInStore(this.uri) ? store.read(this.uri) : buildNotFoundMessage();
+  }
+
+  private String buildNotFoundMessage() {
+    return this.uri + " was not found!";
+  }
+
   private String determineContentType() {
-    return this.store.getFileType(this.uri);
-  }
-
-  private String createMessageBody(int statusCode) {
-    String emptyMessageBody = "";
-    return (statusCode == HttpStatusCode.OK) ? store.read(this.uri) : emptyMessageBody;
-  }
-
-  public int determineContentLength(String messageBody) {
-    int length = 0;
-    try {
-      length = messageBody.getBytes("UTF-8").length;
-    } catch (UnsupportedEncodingException e) {
-      System.err.println(e.getMessage());
-    }
-
-    return length;
-  }
+    return this.store.existsInStore(this.uri) ? this.store.getFileType(this.uri) : "text/plain";
+  } 
 
 }

--- a/src/main/java/Handler/FileHandler.java
+++ b/src/main/java/Handler/FileHandler.java
@@ -20,15 +20,21 @@
 
   private Response buildGETResponse() { 
     int statusCode = determineStatusCode();
+    String contentType = determineContentType();
     String messageBody = createMessageBody(statusCode);
      
     return new Response.Builder(statusCode) 
+                       .contentType(contentType)
                        .messageBody(messageBody) 
                        .build(); 
   } 
 
   private int determineStatusCode() {
-    return store.existsInStore(this.uri) ? HttpStatusCode.OK : HttpStatusCode.NOT_FOUND;
+    return this.store.existsInStore(this.uri) ? HttpStatusCode.OK : HttpStatusCode.NOT_FOUND;
+  }
+
+  private String determineContentType() {
+    return this.store.getFileType(this.uri);
   }
 
   private String createMessageBody(int statusCode) {

--- a/src/main/java/Handler/FileHandler.java
+++ b/src/main/java/Handler/FileHandler.java
@@ -1,3 +1,5 @@
+import java.io.UnsupportedEncodingException;
+
  public class FileHandler implements Handler {
   private DataStore store;
   private String uri;
@@ -22,9 +24,11 @@
     int statusCode = determineStatusCode();
     String contentType = determineContentType();
     String messageBody = createMessageBody(statusCode);
+    int contentLength = ResponseHeader.determineContentLength(messageBody);
      
     return new Response.Builder(statusCode) 
                        .contentType(contentType)
+                       .contentLength(contentLength)
                        .messageBody(messageBody) 
                        .build(); 
   } 
@@ -40,6 +44,17 @@
   private String createMessageBody(int statusCode) {
     String emptyMessageBody = "";
     return (statusCode == HttpStatusCode.OK) ? store.read(this.uri) : emptyMessageBody;
+  }
+
+  public int determineContentLength(String messageBody) {
+    int length = 0;
+    try {
+      length = messageBody.getBytes("UTF-8").length;
+    } catch (UnsupportedEncodingException e) {
+      System.err.println(e.getMessage());
+    }
+
+    return length;
   }
 
 }

--- a/src/main/java/Handler/RootHandler.java
+++ b/src/main/java/Handler/RootHandler.java
@@ -1,4 +1,5 @@
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 
 public class RootHandler implements Handler {
   private Response response;
@@ -13,18 +14,25 @@ public class RootHandler implements Handler {
 
     switch (method) {
       case "GET": 
-        return new Response.Builder(HttpStatusCode.OK)
-                           .messageBody(createMessageBody())
-                           .build();
+        return buildGETResponse();
       default: 
         return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED)
                            .build();
     }
   }
 
-  public String createMessageBody() {
+  private Response buildGETResponse() {
+    String messageBody = createMessageBody();
+    int contentLength = ResponseHeader.determineContentLength(messageBody);
+    return new Response.Builder(HttpStatusCode.OK)
+                       .contentType("text/plain")
+                       .contentLength(contentLength)
+                       .messageBody(messageBody)
+                       .build(); 
+  }
+
+  private String createMessageBody() {
     return this.store.listContent();
   }
 
 }
-  

--- a/src/main/java/Handler/RootHandler.java
+++ b/src/main/java/Handler/RootHandler.java
@@ -14,14 +14,14 @@ public class RootHandler implements Handler {
 
     switch (method) {
       case "GET": 
-        return buildGETResponse();
+        return buildGetResponse();
       default: 
         return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED)
                            .build();
     }
   }
 
-  private Response buildGETResponse() {
+  private Response buildGetResponse() {
     String messageBody = createMessageBody();
     int contentLength = ResponseHeader.determineContentLength(messageBody);
     return new Response.Builder(HttpStatusCode.OK)

--- a/src/main/java/Response/Response.java
+++ b/src/main/java/Response/Response.java
@@ -54,7 +54,7 @@ public class Response {
       return this;
     }
 
-    // delete vvv
+    // delete after merging ft/image-content-negotiation with master vvv
     public Builder contentType(String contentType) {
       this.headers.put(ResponseHeader.CONTENT_TYPE, contentType);
       return this;
@@ -65,7 +65,7 @@ public class Response {
       this.headers.put(ResponseHeader.CONTENT_LENGTH, stringifedContentLength);
       return this;
     }
-    // delete ^^^
+    // delete after merging ft/image-content-negotiation with master  ^^^
 
     public Response build() {
       return new Response(this);
@@ -101,7 +101,11 @@ public class Response {
     return this.headers.get(headerField);
   }
 
-  // delete vvvvv
+  public HashMap getHeaders() {
+    return this.headers;
+  }
+
+  // delete after merging ft/image-content-negotiation with master  vvvvv
   public String getContentType() {
     return this.headers.get(ResponseHeader.CONTENT_TYPE);
   }
@@ -110,19 +114,6 @@ public class Response {
     String stringifiedContentLength = this.headers.get(ResponseHeader.CONTENT_LENGTH);
     return Integer.parseInt(stringifiedContentLength);
   }
-  // delete ^^^
-
-  public String toString() {
-    return getStatusLine() + getHeaders() + "\r\n" + this.messageBody;
-  }
-  
-  private String getStatusLine() {
-    return "HTTP/" + this.version + " " + this.statusCode + " " + this.reasonPhrase + "\r\n";
-  }
-
-  private String getHeaders() {
-    return ResponseHeader.CONTENT_TYPE + ": " + getContentType() + "\n" +
-           ResponseHeader.CONTENT_LENGTH + ": " + getContentLength() + "\r\n";
-  }
+  // delete after merging ft/image-content-negotiation with master  ^^^
 
 }

--- a/src/main/java/Response/Response.java
+++ b/src/main/java/Response/Response.java
@@ -1,20 +1,26 @@
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+
 public class Response {
   private String messageBody;
   private String reasonPhrase;
   private int statusCode;
-  private String version; 
+  private String version;
+  private HashMap<String, String> headers;
 
-  public static class Builder {
+  public static class Builder { 
+    private HashMap<String, String> headers;
     private String messageBody;
     private String reasonPhrase;
     private int statusCode;
-    private String version; 
+    private String version;
 
     public Builder(int statusCode) {
       this.statusCode = statusCode;
       this.reasonPhrase = HttpStatusCode.getReasonPhrase(statusCode);
       this.messageBody = "";
       this.version = "1.1";
+      this.headers = new HashMap<String, String>();
     }
 
     public Builder httpVersion(String version) {
@@ -37,6 +43,30 @@ public class Response {
       return this;
     }
 
+    public Builder setHeader(String headerField, String value) {
+      this.headers.put(headerField, value);
+      return this;
+    }
+
+    public Builder setHeader(String headerField, int value) {
+      String stringifiedValue = Integer.toString(value);
+      this.headers.put(headerField, stringifiedValue);
+      return this;
+    }
+
+    // delete vvv
+    public Builder contentType(String contentType) {
+      this.headers.put(ResponseHeader.CONTENT_TYPE, contentType);
+      return this;
+    }
+
+    public Builder contentLength(int contentLength) {
+      String stringifedContentLength = Integer.toString(contentLength);
+      this.headers.put(ResponseHeader.CONTENT_LENGTH, stringifedContentLength);
+      return this;
+    }
+    // delete ^^^
+
     public Response build() {
       return new Response(this);
     }
@@ -48,6 +78,7 @@ public class Response {
     this.statusCode = builder.statusCode;
     this.reasonPhrase = builder.reasonPhrase;
     this.messageBody = builder.messageBody;
+    this.headers = builder.headers;
   }
 
   public String getHTTPVersion() {
@@ -65,12 +96,33 @@ public class Response {
   public String getMessageBody() {
     return this.messageBody;
   }
+
+  public String getHeader(String headerField) {
+    return this.headers.get(headerField);
+  }
+
+  // delete vvvvv
+  public String getContentType() {
+    return this.headers.get(ResponseHeader.CONTENT_TYPE);
+  }
+
+  public int getContentLength() {
+    String stringifiedContentLength = this.headers.get(ResponseHeader.CONTENT_LENGTH);
+    return Integer.parseInt(stringifiedContentLength);
+  }
+  // delete ^^^
+
   public String toString() {
-    return getStatusLine() + "\r\n" + this.messageBody;
+    return getStatusLine() + getHeaders() + "\r\n" + this.messageBody;
   }
   
   private String getStatusLine() {
     return "HTTP/" + this.version + " " + this.statusCode + " " + this.reasonPhrase + "\r\n";
+  }
+
+  private String getHeaders() {
+    return ResponseHeader.CONTENT_TYPE + ": " + getContentType() + "\n" +
+           ResponseHeader.CONTENT_LENGTH + ": " + getContentLength() + "\r\n";
   }
 
 }

--- a/src/main/java/Response/ResponseFormatter.java
+++ b/src/main/java/Response/ResponseFormatter.java
@@ -1,0 +1,38 @@
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResponseFormatter {
+  Response response;
+  
+  public ResponseFormatter(Response response) {
+    this.response = response;
+  }
+  
+  public String formatResponse() {
+    return formatStatusLine() + 
+           formatHeaders() + 
+           "\r\n" +
+           this.response.getMessageBody();
+  }
+
+  private String formatStatusLine() {
+    return formatHttpVersion() + " " + this.response.getStatusCode() + " " + this.response.getReasonPhrase() + "\r\n";
+  }
+
+  private String formatHttpVersion() {
+    return "HTTP/" + this.response.getHTTPVersion();
+  }
+
+  private String formatHeaders() {
+    String formattedHeaders = "";
+    HashMap<String, String> headersMap = this.response.getHeaders();
+    for (Map.Entry<String, String> fieldValuePair : headersMap.entrySet()) {
+      String field = fieldValuePair.getKey();
+      Object value = fieldValuePair.getValue();
+      formattedHeaders += field + ": " + value + "\r\n";
+    }
+    
+    return formattedHeaders;
+  }
+
+}

--- a/src/main/java/Response/ResponseHeader.java
+++ b/src/main/java/Response/ResponseHeader.java
@@ -1,0 +1,18 @@
+import java.io.UnsupportedEncodingException;
+
+public class ResponseHeader {
+  public final static String CONTENT_LENGTH = "Content-Length";
+  public final static String CONTENT_TYPE = "Content-Type";
+  
+  public static int determineContentLength(String messageBody) {
+    int length = 0;
+    try {
+      length = messageBody.getBytes("UTF-8").length;
+    } catch (UnsupportedEncodingException e) {
+      System.err.println(e.getMessage());
+    }
+
+    return length;
+  }
+  
+}

--- a/src/test/java/Response/ResponseFormatterTest.java
+++ b/src/test/java/Response/ResponseFormatterTest.java
@@ -1,0 +1,32 @@
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ResponseFormatterTest {
+  private final static String HTTP_VERSION = "1.1";
+  private final static int STATUS_CODE = HttpStatusCode.OK;
+  private final static String REASON_PHRASE = "OK";
+  private final static String CONTENT_TYPE = "text/plain";
+  private final static int CONTENT_LENGTH = 13;
+  private final static String MESSAGE_BODY = "Hello, world!";
+
+  private Response response = new Response.Builder(STATUS_CODE)
+                                          .httpVersion(HTTP_VERSION)
+                                          .reasonPhrase(REASON_PHRASE)
+                                          .contentType(CONTENT_TYPE)
+                                          .contentLength(CONTENT_LENGTH)
+                                          .messageBody(MESSAGE_BODY)
+                                          .build();
+
+  @Test 
+  public void formatsResponseWithHeaders() {
+    ResponseFormatter formatter = new ResponseFormatter(response);        
+    String expectedResponse = 
+      "HTTP/" + HTTP_VERSION + " " + STATUS_CODE + " " + REASON_PHRASE + "\r\n" +
+      ResponseHeader.CONTENT_LENGTH + ": " + CONTENT_LENGTH + "\r\n" +
+      ResponseHeader.CONTENT_TYPE + ": " + CONTENT_TYPE + "\r\n" +
+      "\r\n" + 
+      MESSAGE_BODY;
+    assertEquals(expectedResponse, formatter.formatResponse());
+  }
+
+}

--- a/src/test/java/Response/ResponseHeaderTest.java
+++ b/src/test/java/Response/ResponseHeaderTest.java
@@ -1,0 +1,14 @@
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ResponseHeaderTest {
+
+  @Test 
+  public void returnsTheCorrectContentLengthForText() {
+    String sampleText = "Hello, world!";
+    int expectedLength = 13;
+
+    assertEquals(expectedLength, ResponseHeader.determineContentLength(sampleText));
+  }
+
+}

--- a/src/test/java/Response/ResponseTest.java
+++ b/src/test/java/Response/ResponseTest.java
@@ -1,5 +1,6 @@
 import java.io.UnsupportedEncodingException;
 import static org.junit.Assert.assertEquals;
+import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,6 +35,12 @@ public class ResponseTest {
   }
 
   @Test 
+  public void getsHeadersHashMap() {
+    HashMap<String, String> headers = response.getHeaders();
+    assertEquals(CONTENT_TYPE, headers.get(ResponseHeader.CONTENT_TYPE));
+  }
+
+  @Test 
   public void setsHeadersWithAStringValue() {
     assertEquals(CONTENT_TYPE, response.getHeader(ResponseHeader.CONTENT_TYPE));
   }
@@ -42,15 +49,6 @@ public class ResponseTest {
   public void setsHeadersWithAnIntValue() {
     String stringifiedContentLength = Integer.toString(CONTENT_LENGTH);
     assertEquals(stringifiedContentLength, response.getHeader(ResponseHeader.CONTENT_LENGTH));
-  }
-
-  @Test
-  public void getsStringifiedResponseWithCarriageReturnsAndNewLines() {
-    assertEquals("HTTP/1.1 200 OK\r\n" +
-                 "Content-Type: text/plain\n" + 
-                 "Content-Length: 13" +  "\r\n" +
-                 "\r\n" + 
-                 "Hello, world!", response.toString());
   }
 
 }

--- a/src/test/java/Response/ResponseTest.java
+++ b/src/test/java/Response/ResponseTest.java
@@ -1,17 +1,26 @@
+import java.io.UnsupportedEncodingException;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
 public class ResponseTest {
+  private final static String HTTP_VERSION = "1.1";
+  private final static String REASON_PHRASE = "OK";
+  private final static String CONTENT_TYPE = "text/plain";
+  private final static int CONTENT_LENGTH = 13;
+  private final static String MESSAGE_BODY = "Hello, world!"; 
+
   private Response response = new Response.Builder(HttpStatusCode.OK)
-                                          .httpVersion("1.1")
-                                          .reasonPhrase("OK")
-                                          .messageBody("Hello, world!")
-                                          .build();
+                      .httpVersion(HTTP_VERSION)
+                      .reasonPhrase(REASON_PHRASE)
+                      .setHeader(ResponseHeader.CONTENT_TYPE, CONTENT_TYPE)
+                      .setHeader(ResponseHeader.CONTENT_LENGTH, CONTENT_LENGTH)
+                      .messageBody(MESSAGE_BODY)
+                      .build();
   
   @Test 
   public void getsHTTPVersion() {
-    assertEquals("1.1", response.getHTTPVersion());
+    assertEquals(HTTP_VERSION, response.getHTTPVersion());
   }
 
   @Test 
@@ -19,19 +28,27 @@ public class ResponseTest {
     assertEquals(200, response.getStatusCode());
   }
 
-  @Test 
-  public void getsReasonPhrase() {
-    assertEquals("OK", response.getReasonPhrase());
+  @Test
+  public void getsMessageBody() {
+    assertEquals(MESSAGE_BODY, response.getMessageBody());
   }
 
-  @Test
-  public void setsMessageBody() {
-    assertEquals("Hello, world!", response.getMessageBody());
+  @Test 
+  public void setsHeadersWithAStringValue() {
+    assertEquals(CONTENT_TYPE, response.getHeader(ResponseHeader.CONTENT_TYPE));
+  }
+
+  @Test 
+  public void setsHeadersWithAnIntValue() {
+    String stringifiedContentLength = Integer.toString(CONTENT_LENGTH);
+    assertEquals(stringifiedContentLength, response.getHeader(ResponseHeader.CONTENT_LENGTH));
   }
 
   @Test
   public void getsStringifiedResponseWithCarriageReturnsAndNewLines() {
     assertEquals("HTTP/1.1 200 OK\r\n" +
+                 "Content-Type: text/plain\n" + 
+                 "Content-Length: 13" +  "\r\n" +
                  "\r\n" + 
                  "Hello, world!", response.toString());
   }


### PR DESCRIPTION
## Response
This class adds a new instance variable `headers`, a HashMap. The setters (`#contentType` and `#contentLength`) are called and calculated from the individual `Handler` building the response. 

## ResponseHeader
This class currently contains static constants for the header names and a static method `determineContentLength(String messageBody)`. The constants help dry the getters and setters for the headers in `Response`, which were originally hard-coded Strings. The method prevents each `Handler` from having to implement identical code to determine the byte length of their respective responses. 

## FileHandler
My greatest concern with this class involves concurrency. `Main` constructs a new `FileHandler` to be used for any requests for files. When`FileHandler` receives a request via `generateResponse(Request request)`, I set `this.uri = request.getURI()`. I know that this can cause concurrency problems because multiple threads could be accessing `FileHandler`, and they could be manipulating `uri` in an unintended order. This is what it looks like below now:

```Java 
public Response generateResponse(Request request) { 
    this.uri = request.getURI();
     
    switch (request.getMethod()) { 
      case "GET":  
        return buildGetResponse(); 
      default:  
        return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED) 
                           .build(); 
    } 
  }

  private Response buildGetResponse() {
    int statusCode = determineStatusCode();
    String messageBody = createMessageBody();
    int contentLength = ResponseHeader.determineContentLength(messageBody);
    String contentType = determineContentType();
    return new Response.Builder(statusCode)
                       .messageBody(messageBody)
                       .contentLength(contentLength)
                       .contentType(contentType)
                       .build();
  }

  private int determineStatusCode() {
    return this.store.existsInStore(this.uri) ? HttpStatusCode.OK : HttpStatusCode.NOT_FOUND;
  }

  private String createMessageBody() {
    return this.store.existsInStore(this.uri) ? store.read(this.uri) : buildNotFoundMessage();
  }

  private String buildNotFoundMessage() {
    return this.uri + " was not found!";
  }

  private String determineContentType() {
    return this.store.existsInStore(this.uri) ? this.store.getFileType(this.uri) : "text/plain";
  } 
```

The alternative seems to be to pass in the `uri` to every private helper method rather than rely on an instance variable. Does this seem like a suitable alternative? Additionally, it seems to me that `FileHandler` has two reasons to change: 
1. `FileHandler` can handle more HTTP methods. This scenario would require creating an additional `case` inside of `generateResponse(Request request)` and, possibly, an additional helper method to build that response. 
2. `FileHandler` begins to respond with more complex headers. This scenario would require adding an additional builder method to `Response.Builder` and, possibly, an additional helper method to determine what that header is. Because every`Handler` currently builds its own headers, I'll have to update three `Handlers` (possibly more in the future) for every new header added to the server.

`Response` is immutable once it is constructed, so it would be difficult to build a `Response` and headers separately. To make things more complicated, populating the headers requires knowing something about `Response` (namely the `messageBody`). Because headers are almost like metadata, it seems to me that `Response` and `FileHandler` know too much. I wouldn't be opposed to moving the logic for calculating and populating the Headers out of these two classes, but I'm not sure which class would reasonably be responsible for those tasks.   