### PR TITLE
Respond to Requests to / With HTML, Creating Clickable Links 

### DIFF
--- a/src/main/java/DataStore/DataStore.java
+++ b/src/main/java/DataStore/DataStore.java
@@ -1,6 +1,6 @@
 public interface DataStore {
 
-  public String listContent();
+  public String[] listContent();
   public Boolean existsInStore(String uri);
   public byte[] readFile(String uri);
   public String getFileType(String uri);

--- a/src/main/java/DataStore/Directory.java
+++ b/src/main/java/DataStore/Directory.java
@@ -30,9 +30,8 @@ public class Directory implements DataStore {
     }
   }
 
-  public String listContent() {
-    String[] contentsOfDirectory = this.directory.list();
-    return stringifyContentsOfDirectory(contentsOfDirectory);
+  public String[] listContent() {
+    return this.directory.list();
   }
 
   public Boolean existsInStore(String uri) {
@@ -56,20 +55,6 @@ public class Directory implements DataStore {
     String filePath = this.directoryPath + uri;
     String extension = getExtension(filePath);
     return MIME_TYPES.getOrDefault(extension, DEFAULT_FILE_TYPE);
-  }
-  
-  private String stringifyContentsOfDirectory(String[] fileNames) {
-    String content = "";
-    
-    if (fileNames.length == 0) {
-      return "Empty directory!";
-    }
-    
-    for (String fileName : fileNames) {
-      content += fileName + "\n";
-    }
-    
-    return content;
   }
 
   private String getExtension(String filePath) {

--- a/src/main/java/Handler/RootHandler.java
+++ b/src/main/java/Handler/RootHandler.java
@@ -26,12 +26,20 @@ public class RootHandler implements Handler {
     int contentLength = ResponseHeader.determineContentLength(messageBody);
     return new Response.Builder(HttpStatusCode.OK)
                        .setHeader(ResponseHeader.CONTENT_LENGTH, contentLength)
+                       .setHeader(ResponseHeader.CONTENT_TYPE, "text/html")
                        .messageBody(messageBody)
                        .build(); 
   }
 
   private String createMessageBody() {
-    return this.store.listContent();
+    String htmlResponse = "";
+    String[] files = this.store.listContent();
+    for (String file : files) {
+      htmlResponse += String.format(
+        "<a href=\"/%s\">%s</a><br>", file, file);
+    } 
+
+    return htmlResponse;
   }
 
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,9 +1,10 @@
 import java.util.HashMap;
  
 public class Main {
+  private static final int DEFAULT_PORT_NUMBER = 8888;
+  
   private static CLIParser parser;
   private static DataStore store;
-  private static final int DEFAULT_PORT_NUMBER = 8888;
  
   public static void main(String[] args) {
     try {
@@ -12,8 +13,8 @@ public class Main {
       DataStore store = extractDataStore();
       Handler defaultHandler = new FileHandler(store);
  
-      Router router = setUpRouter(defaultHandler);
       int port = parser.getPortNumberOrDefault(DEFAULT_PORT_NUMBER);
+      Router router = setUpRouter(defaultHandler);
       Server server = new Server(port, router);
       server.start();
     } catch (ArrayIndexOutOfBoundsException e) {

--- a/src/main/java/Response/Response.java
+++ b/src/main/java/Response/Response.java
@@ -20,6 +20,7 @@ public class Response {
       this.reasonPhrase = HttpStatusCode.getReasonPhrase(statusCode);
       this.version = "1.1";
       this.headers = new HashMap<String, String>();
+      this.messageBody = "".getBytes();
     }
 
     public Builder httpVersion(String version) {

--- a/src/test/java/DataStore/DirectoryTest.java
+++ b/src/test/java/DataStore/DirectoryTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 
 public class DirectoryTest {
   private final static String EMPTY_TEXT_FILE_URI = "/empty-file.txt";
-  private final static String HTML_FILE_URI = "/html-file.html";
   private final static String NONEXISTENT_FILE_URI = "/does-not-exist.txt";
   private final static String TEXT_FILE_CONTENT = "This is a sample text file.";
   private final static String TEXT_FILE_URI = "/text-file.txt";
@@ -37,9 +36,12 @@ public class DirectoryTest {
   }
 
   @Test 
-  public void listsDirectoryContent() {
-    assertEquals("empty-file.txt\n" +
-                 "text-file.txt\n", directory.listContent());
+  public void listsDirectoryContentAsArray() {
+    String[] directoryContent = directory.listContent();
+    String emptyTextFileName = TestUtil.removeLeadingParenthesesFromUri(EMPTY_TEXT_FILE_URI);
+    String textFileName = TestUtil.removeLeadingParenthesesFromUri(TEXT_FILE_URI);
+    assertTrue(Arrays.asList(directoryContent).contains(emptyTextFileName));
+    assertTrue(Arrays.asList(directoryContent).contains(textFileName));
   }
   
   @Test
@@ -65,4 +67,3 @@ public class DirectoryTest {
   }
   
 }
-

--- a/src/test/java/Handler/RootHandlerTest.java
+++ b/src/test/java/Handler/RootHandlerTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 public class RootHandlerTest {
   private final static String HTML_FILE_URI = "/html-file.html";
   private final static String TEXT_FILE_URI = "/text-file.txt";
-  private final static int PORT = 8888;
   
   private static Handler handler; 
   
@@ -19,7 +18,7 @@ public class RootHandlerTest {
     temp.createEmptyFile(HTML_FILE_URI);
 
     Directory directory = new Directory(tempDirectoryPath); 
-    handler = new RootHandler(directory, PORT); 
+    handler = new RootHandler(directory); 
   }
     
   @Test 
@@ -31,7 +30,7 @@ public class RootHandlerTest {
                                  .build();   
 
     String[] uris = { HTML_FILE_URI, TEXT_FILE_URI };
-    String expectedHtml = createExpectedHtmlFromFileUris(uris);
+    String expectedHtml = TestUtil.createRootHtmlFromUris(uris);
     String messageBody = new String(handler.generateResponse(request).getMessageBody());
     assertEquals(expectedHtml, messageBody);
   }
@@ -49,16 +48,4 @@ public class RootHandlerTest {
     assertEquals("Method Not Allowed", response.getReasonPhrase()); 
   }
 
-  private String createExpectedHtmlFromFileUris(String[] uris) {
-    String expectedHtml = "";
-    for (String uri : uris) {
-      String fileName = TestUtil.removeLeadingParenthesesFromUri(uri);
-      expectedHtml += String.format(
-        "<a href=\"http://localhost:%d/%s\">%s</a>" + 
-        "<br>", PORT, fileName, fileName);
-    }
-
-    return expectedHtml;
-  }
-  
 }

--- a/src/test/java/Handler/RootHandlerTest.java
+++ b/src/test/java/Handler/RootHandlerTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 public class RootHandlerTest {
   private final static String HTML_FILE_URI = "/html-file.html";
   private final static String TEXT_FILE_URI = "/text-file.txt";
+  private final static int PORT = 8888;
   
   private static Handler handler; 
   
@@ -18,24 +19,22 @@ public class RootHandlerTest {
     temp.createEmptyFile(HTML_FILE_URI);
 
     Directory directory = new Directory(tempDirectoryPath); 
-    handler = new RootHandler(directory); 
+    handler = new RootHandler(directory, PORT); 
   }
     
-  @Test
-  public void returnContentsOfDirectory() {
+  @Test 
+  public void returneContentsOfDirectoryAsHtml() {
     Request request = new Request.Builder()
                                  .method("GET")
                                  .uri("/")
                                  .version("1.1")
-                                 .build();                           
-  
+                                 .build();   
 
-    String expectedMessageBody = removeLeadingParentheses(HTML_FILE_URI) + "\n" +  
-                                 removeLeadingParentheses(TEXT_FILE_URI) + "\n"; 
-    Response response = handler.generateResponse(request);
-    String stringifiedMessageBody = new String(response.getMessageBody());
-    assertEquals(expectedMessageBody, stringifiedMessageBody);
-  }  
+    String[] uris = { HTML_FILE_URI, TEXT_FILE_URI };
+    String expectedHtml = createExpectedHtmlFromFileUris(uris);
+    String messageBody = new String(handler.generateResponse(request).getMessageBody());
+    assertEquals(expectedHtml, messageBody);
+  }
   
   @Test
   public void return405MethodNotAllowed() {
@@ -50,9 +49,16 @@ public class RootHandlerTest {
     assertEquals("Method Not Allowed", response.getReasonPhrase()); 
   }
 
-  private String removeLeadingParentheses(String uri) {
-    int idxOfFirstCharacter = 1;
-    return uri.substring(idxOfFirstCharacter);
+  private String createExpectedHtmlFromFileUris(String[] uris) {
+    String expectedHtml = "";
+    for (String uri : uris) {
+      String fileName = TestUtil.removeLeadingParenthesesFromUri(uri);
+      expectedHtml += String.format(
+        "<a href=\"http://localhost:%d/%s\">%s</a>" + 
+        "<br>", PORT, fileName, fileName);
+    }
+
+    return expectedHtml;
   }
   
 }

--- a/src/test/java/Response/ResponseFormatterTest.java
+++ b/src/test/java/Response/ResponseFormatterTest.java
@@ -9,25 +9,45 @@ public class ResponseFormatterTest {
   private final static int CONTENT_LENGTH = 13;
   private final static String MESSAGE_BODY = "Hello, world!";
 
-  private Response response = new Response.Builder(STATUS_CODE)
+  @Test 
+  public void formatsResponseWithMessage() {
+    Response response = new Response.Builder(STATUS_CODE)
                       .httpVersion(HTTP_VERSION)
                       .reasonPhrase(REASON_PHRASE)
                       .setHeader(ResponseHeader.CONTENT_LENGTH, CONTENT_LENGTH)
                       .setHeader(ResponseHeader.CONTENT_TYPE, CONTENT_TYPE)
                       .messageBody(MESSAGE_BODY)
                       .build();
+    ResponseFormatter formatter = new ResponseFormatter(response);   
+
+    String expectedResponse = createExpectedResponseWithMessageBodyAndHeaders();
+    String stringifiedFormattedResp = new String(formatter.formatResponse());
+    assertEquals(expectedResponse, stringifiedFormattedResp);
+  }
 
   @Test 
-  public void formatsResponseWithHeaders() {
+  public void formatsResponseWithoutMessage() {
+    Response response = new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED)
+                                    .build();
     ResponseFormatter formatter = new ResponseFormatter(response);        
-    String expectedResponse = 
-      "HTTP/" + HTTP_VERSION + " " + STATUS_CODE + " " + REASON_PHRASE + "\r\n" +
+
+    String expectedResponse = createExpectedResponseWithNoMessageBody();
+    String stringifiedFormattedResp = new String(formatter.formatResponse());
+    assertEquals(expectedResponse, stringifiedFormattedResp);
+  }
+
+  private String createExpectedResponseWithMessageBodyAndHeaders() {
+    return "HTTP/" + HTTP_VERSION + " " + STATUS_CODE + " " + REASON_PHRASE + "\r\n" +
       ResponseHeader.CONTENT_LENGTH + ": " + CONTENT_LENGTH + "\r\n" +
       ResponseHeader.CONTENT_TYPE + ": " + CONTENT_TYPE + "\r\n" +
       "\r\n" + 
       MESSAGE_BODY;
-    String stringifiedFormattedResponse = new String(formatter.formatResponse());
-    assertEquals(expectedResponse, stringifiedFormattedResponse);
+  }
+
+  private String createExpectedResponseWithNoMessageBody() {
+    int statusCode = HttpStatusCode.METHOD_NOT_ALLOWED;
+    return "HTTP/" + HTTP_VERSION + " " + statusCode + " " + HttpStatusCode.getReasonPhrase(statusCode) + "\r\n" +
+    "\r\n";
   }
 
 }

--- a/src/test/java/StepDefinitions/RootSteps.java
+++ b/src/test/java/StepDefinitions/RootSteps.java
@@ -11,14 +11,15 @@ import static org.junit.Assert.assertEquals;
 import org.junit.After; 
 
 public class RootSteps {
+  private final static int PORT = 8888; 
+
   private HttpURLConnection con;
   private String responseReasonPhrase;
   private Server server;
-  private int port = 8888; 
 
   @When("^a client makes a GET request to /$")
   public void a_client_makes_a_GET_request_to() throws Throwable {
-    String urlString = String.format("http://localhost:%d/", this.port);
+    String urlString = String.format("http://localhost:%d/", PORT);
     URL url = new URL(urlString);
     this.con = (HttpURLConnection) url.openConnection();
     
@@ -42,7 +43,7 @@ public class RootSteps {
       "/software-developurr.gif"
     };
 
-    String expectedResponseMessageBody = createExpectedHtmlFromFileUris(fileUris) + "\n";
+    String expectedResponseMessageBody = TestUtil.createRootHtmlFromUris(fileUris) + "\n";
     assertEquals(expectedResponseMessageBody, messageBody);
   }
 
@@ -53,23 +54,11 @@ public class RootSteps {
 
   @When("^a client makes a GET request to any other endpoint$")
   public void a_client_makes_a_GET_request_to_any_other_endpoint() throws Throwable {
-    String urlString = String.format("http://localhost:%d/any/other/endpoint", this.port);
+    String urlString = String.format("http://localhost:%d/any/other/endpoint", PORT);
     URL url = new URL(urlString);
     this.con = (HttpURLConnection) url.openConnection();
     
     this.responseReasonPhrase = con.getResponseMessage();
-  }
-
-  private String createExpectedHtmlFromFileUris(String[] uris) {
-    String expectedHtml = "";
-    for (String uri : uris) {
-      String fileName = TestUtil.removeLeadingParenthesesFromUri(uri);
-      expectedHtml += String.format(
-        "<a href=\"http://localhost:%d/%s\">%s</a>" + 
-        "<br>", port, fileName, fileName);
-    }
-
-    return expectedHtml;
   }
 
 }

--- a/src/test/java/StepDefinitions/RootSteps.java
+++ b/src/test/java/StepDefinitions/RootSteps.java
@@ -29,16 +29,20 @@ public class RootSteps {
   public void the_server_should_respond_with_the_contents_of_the_directory_of_where_the_JAR_is_running() throws Throwable {
     String messageBody = StepDefsUtil.readMessageBody(this.con);  
 
-    String expectedResponseMessageBody = "around-the-world.txt\n" + 
-                                         "cat-and-dog.jpg\n" +
-                                         "fresh-prince-of-bel-air.txt\n" +
-                                         "git-pull.gif\n" +
-                                         "git-push-force.gif\n" +
-                                         "git-push.gif\n" +
-                                         "purr-programming.jpg\n" +
-                                         "sample-text.txt\n" + 
-                                         "smiley-cat.png\n" +
-                                         "software-developurr.gif\n";
+    String[] fileUris = {
+      "/around-the-world.txt", 
+      "/cat-and-dog.jpg",
+      "/fresh-prince-of-bel-air.txt",
+      "/git-pull.gif",
+      "/git-push-force.gif",
+      "/git-push.gif",
+      "/purr-programming.jpg",
+      "/sample-text.txt", 
+      "/smiley-cat.png",
+      "/software-developurr.gif"
+    };
+
+    String expectedResponseMessageBody = createExpectedHtmlFromFileUris(fileUris) + "\n";
     assertEquals(expectedResponseMessageBody, messageBody);
   }
 
@@ -54,6 +58,18 @@ public class RootSteps {
     this.con = (HttpURLConnection) url.openConnection();
     
     this.responseReasonPhrase = con.getResponseMessage();
+  }
+
+  private String createExpectedHtmlFromFileUris(String[] uris) {
+    String expectedHtml = "";
+    for (String uri : uris) {
+      String fileName = TestUtil.removeLeadingParenthesesFromUri(uri);
+      expectedHtml += String.format(
+        "<a href=\"http://localhost:%d/%s\">%s</a>" + 
+        "<br>", port, fileName, fileName);
+    }
+
+    return expectedHtml;
   }
 
 }

--- a/src/test/java/util/TestUtil.java
+++ b/src/test/java/util/TestUtil.java
@@ -1,8 +1,22 @@
 public class TestUtil {
 
+  public static String createRootHtmlFromUris(String[] uris) {
+    String expectedHtml = "";
+    for (String uri : uris) {
+      String fileName = TestUtil.removeLeadingParenthesesFromUri(uri);
+      expectedHtml += String.format(
+        "<a href=\"/%s\">%s</a>" + 
+        "<br>", fileName, fileName);
+    }
+
+    return expectedHtml;
+  }
+  
   public static String removeLeadingParenthesesFromUri(String uri) {
     int idxOfFirstCharacter = 1;
     return uri.substring(idxOfFirstCharacter);
   }
+
+  
 
 }


### PR DESCRIPTION
## RootHandler 
In order to create clickable links, `RootHandler` builds `Response`s to GET requests with HTML. The `createMessageBody()` method iterates over every file name returned by the `Directory`. Because `RootHandler` now takes a port number upon instantiation, it uses the file name and the port number to create an anchor tag with an href pointing to the file's location in the server. Once in the browser, clicking on the link changes the URL displayed on the address bar. 

## TestUtil 
In order to build the expected `messageBody` against which to run assertions, the `createRootHtmlFromUrisAndPort(String[] uris, int port)` takes an array of URIs and a port number. It uses the two arguments to iterate over every URI, creating an href to the proper URL. 

## Response 
After adding response headers, I had not realized that I introduced a bug where the `ResponseFormatter` threw a `NullPointerException` whenever formatting `Response`s that had not set a `messageBody`. This was most notable when attempting to format `Response`s for `405 Method Not Allowed`. I remedied this by setting a default `messageBody` of `"".getBytes()`. 

## ResponseFormatterTest
In order to ensure that I'm aware of a similar issue in the future, I've created a new assertion (`formatsResponseWithoutMessage()`) within this class. I also took the opportunity to refactor the logic for creating `expectedResponse`s into their own helper methods. 