### PR TITLE
Reply to HEAD Requests with Headers and No Message Body

### DIFF
--- a/src/main/java/Handler/EchoHandler.java
+++ b/src/main/java/Handler/EchoHandler.java
@@ -12,6 +12,8 @@ public class EchoHandler implements Handler {
     String statusCodeAndReasonPhrase;
     String messageBody = "";
     switch (method) {
+      case "HEAD": 
+        return buildHeadResponse();
       case "GET": 
         return buildGetResponse();
       default: 
@@ -20,10 +22,20 @@ public class EchoHandler implements Handler {
     }
   }
 
+  private Response buildHeadResponse() {
+    String messageBody = createMessageBody();
+    int contentLength = ResponseHeader.determineContentLength(messageBody);
+    return new Response.Builder(HttpStatusCode.OK)
+                       .setHeader(ResponseHeader.CONTENT_TYPE, "text/plain")
+                       .setHeader(ResponseHeader.CONTENT_LENGTH, contentLength)
+                       .build();
+  }
+
   private Response buildGetResponse() {
     String messageBody = createMessageBody();
     int contentLength = ResponseHeader.determineContentLength(messageBody);
     return new Response.Builder(HttpStatusCode.OK)
+                       .setHeader(ResponseHeader.CONTENT_TYPE, "text/plain")
                        .setHeader(ResponseHeader.CONTENT_LENGTH, contentLength)
                        .messageBody(messageBody)
                        .build();

--- a/src/main/java/Handler/FileHandler.java
+++ b/src/main/java/Handler/FileHandler.java
@@ -2,41 +2,41 @@ import java.io.UnsupportedEncodingException;
 
  public class FileHandler implements Handler {   
   private DataStore store;
-  private String uri;
   
   public FileHandler(DataStore store) {
     this.store = store;
   }
   
   public Response generateResponse(Request request) { 
-    this.uri = request.getURI();
+    String uri = request.getURI();
      
     switch (request.getMethod()) { 
       case "HEAD":  
-        return buildHeadResponse(); 
+        return buildHeadResponse(uri); 
       case "GET":  
-        return buildGetResponse(); 
+        return buildGetResponse(uri); 
       default:  
         return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED) 
                            .build(); 
     } 
   }
 
-  private Response buildHeadResponse() {
-    int statusCode = determineStatusCode();
-    byte[] messageBody = createMessageBody();
+  private Response buildHeadResponse(String uri) {
+    int statusCode = determineStatusCode(uri);
+    byte[] messageBody = createMessageBody(uri);
     int contentLength = messageBody.length;
-    String contentType = determineContentType();
+    String contentType = determineContentType(uri);
     return new Response.Builder(statusCode)
                        .setHeader(ResponseHeader.CONTENT_LENGTH, contentLength)
                        .setHeader(ResponseHeader.CONTENT_TYPE, contentType)
                        .build();
   }
-  private Response buildGetResponse() {
-    int statusCode = determineStatusCode();
-    byte[] messageBody = createMessageBody();
+  
+  private Response buildGetResponse(String uri) {
+    int statusCode = determineStatusCode(uri);
+    byte[] messageBody = createMessageBody(uri);
     int contentLength = messageBody.length;
-    String contentType = determineContentType();
+    String contentType = determineContentType(uri);
     return new Response.Builder(statusCode)
                        .messageBody(messageBody)
                        .setHeader(ResponseHeader.CONTENT_LENGTH, contentLength)
@@ -44,20 +44,20 @@ import java.io.UnsupportedEncodingException;
                        .build();
   }
 
-  private int determineStatusCode() {
-    return this.store.existsInStore(this.uri) ? HttpStatusCode.OK : HttpStatusCode.NOT_FOUND;
+  private int determineStatusCode(String uri) {
+    return this.store.existsInStore(uri) ? HttpStatusCode.OK : HttpStatusCode.NOT_FOUND;
   }
 
-  private byte[] createMessageBody() {
-    return this.store.existsInStore(this.uri) ? store.readFile(this.uri) : buildNotFoundMessage().getBytes();
+  private byte[] createMessageBody(String uri) {
+    return this.store.existsInStore(uri) ? store.readFile(uri) : buildNotFoundMessage(uri).getBytes();
   }
 
-  private String buildNotFoundMessage() {
-    return this.uri + " was not found!";
+  private String buildNotFoundMessage(String uri) {
+    return uri + " was not found!";
   }
 
-  private String determineContentType() {
-    return this.store.existsInStore(this.uri) ? this.store.getFileType(this.uri) : "text/plain";
+  private String determineContentType(String uri) {
+    return this.store.existsInStore(uri) ? this.store.getFileType(uri) : "text/plain";
   } 
 
 }

--- a/src/main/java/Handler/FileHandler.java
+++ b/src/main/java/Handler/FileHandler.java
@@ -12,6 +12,8 @@ import java.io.UnsupportedEncodingException;
     this.uri = request.getURI();
      
     switch (request.getMethod()) { 
+      case "HEAD":  
+        return buildHeadResponse(); 
       case "GET":  
         return buildGetResponse(); 
       default:  
@@ -20,6 +22,16 @@ import java.io.UnsupportedEncodingException;
     } 
   }
 
+  private Response buildHeadResponse() {
+    int statusCode = determineStatusCode();
+    byte[] messageBody = createMessageBody();
+    int contentLength = messageBody.length;
+    String contentType = determineContentType();
+    return new Response.Builder(statusCode)
+                       .setHeader(ResponseHeader.CONTENT_LENGTH, contentLength)
+                       .setHeader(ResponseHeader.CONTENT_TYPE, contentType)
+                       .build();
+  }
   private Response buildGetResponse() {
     int statusCode = determineStatusCode();
     byte[] messageBody = createMessageBody();

--- a/src/main/java/Handler/RootHandler.java
+++ b/src/main/java/Handler/RootHandler.java
@@ -13,12 +13,23 @@ public class RootHandler implements Handler {
     String method = request.getMethod();
 
     switch (method) {
+      case "HEAD": 
+        return buildHeadResponse();
       case "GET": 
         return buildGetResponse();
       default: 
         return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED)
                            .build();
     }
+  }
+
+  private Response buildHeadResponse() {
+    String messageBody = createMessageBody();
+    int contentLength = ResponseHeader.determineContentLength(messageBody);
+    return new Response.Builder(HttpStatusCode.OK)
+                       .setHeader(ResponseHeader.CONTENT_LENGTH, contentLength)
+                       .setHeader(ResponseHeader.CONTENT_TYPE, "text/html")
+                       .build(); 
   }
 
   private Response buildGetResponse() {

--- a/src/test/java/Handler/EchoHandlerTest.java
+++ b/src/test/java/Handler/EchoHandlerTest.java
@@ -23,6 +23,20 @@ public class EchoHandlerTest {
     assertEquals(expectedMessageBody, stringifiedMessageBody);
   }
 
+  @Test 
+  public void returnsOnlyHeadersForHeadRequest() {
+    Request request = new Request.Builder()
+                                 .method("HEAD")
+                                 .uri("/echo")
+                                 .version("1.1")
+                                 .build();   
+                                 
+    Response response = handler.generateResponse(request);
+    String messageBody = new String(response.getMessageBody());
+    assertEquals(200, response.getStatusCode()); 
+    assertEquals("", messageBody); 
+  }
+
   private String createExpectedMessageBody() {
     String formattedTime = getFormattedTime();
     return "Hello, world: " + formattedTime;

--- a/src/test/java/Handler/FileHandlerTest.java
+++ b/src/test/java/Handler/FileHandlerTest.java
@@ -42,6 +42,20 @@ public class FileHandlerTest {
     assertEquals(TEXT_FILE_CONTENT, stringifiedMessageBody);
   } 
 
+  @Test 
+  public void returnsOnlyHeadersForHeadRequest() {
+    Request request = new Request.Builder()
+                                 .method("HEAD")
+                                 .uri("/text-file.txt")
+                                 .version("1.1")
+                                 .build();   
+                                 
+    Response response = handler.generateResponse(request);
+    String messageBody = new String(response.getMessageBody());
+    assertEquals(200, response.getStatusCode()); 
+    assertEquals("", messageBody); 
+  }
+
   private static Request buildRequestToNonexistentFile() { 
   return new Request.Builder() 
                     .method("GET") 

--- a/src/test/java/Handler/RootHandlerTest.java
+++ b/src/test/java/Handler/RootHandlerTest.java
@@ -38,6 +38,20 @@ public class RootHandlerTest {
     assertEquals(expectedHtml, messageBody);
   }
   
+  @Test 
+  public void returnsOnlyHeadersForHeadRequest() {
+    Request request = new Request.Builder()
+                                 .method("HEAD")
+                                 .uri("/")
+                                 .version("1.1")
+                                 .build();   
+                                 
+    Response response = handler.generateResponse(request);
+    String messageBody = new String(response.getMessageBody());
+    assertEquals(200, response.getStatusCode()); 
+    assertEquals("", messageBody); 
+  }
+  
   @Test
   public void return405MethodNotAllowed() {
     Request request = new Request.Builder()

--- a/src/test/java/StepDefinitions/HeaderStepDefs.java
+++ b/src/test/java/StepDefinitions/HeaderStepDefs.java
@@ -12,7 +12,7 @@ public class HeaderStepDefs {
   }
 
   @Then("^the server should respond with the header (.+) (.+)$")
-  public void the_server_should_respond_with_the_header_Content_Type_text_plain(String field, String expectedValue) throws Throwable {
+  public void the_server_should_respond_with_the_header(String field, String expectedValue) throws Throwable {
     assertEquals(expectedValue, this.world.con.getHeaderField(field));
   }
 

--- a/src/test/java/StepDefinitions/HeaderStepDefs.java
+++ b/src/test/java/StepDefinitions/HeaderStepDefs.java
@@ -1,0 +1,19 @@
+import cucumber.api.java.en.Then;
+import cucumber.api.PendingException;
+import java.util.Arrays;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HeaderStepDefs {
+  private World world;
+
+  public HeaderStepDefs(World world) {
+    this.world = world;
+  }
+
+  @Then("^the server should respond with the header (.+) (.+)$")
+  public void the_server_should_respond_with_the_header_Content_Type_text_plain(String field, String expectedValue) throws Throwable {
+    assertEquals(expectedValue, this.world.con.getHeaderField(field));
+  }
+
+}

--- a/src/test/java/StepDefinitions/RequestStepDefs.java
+++ b/src/test/java/StepDefinitions/RequestStepDefs.java
@@ -13,12 +13,13 @@ public class RequestStepDefs {
     this.world = world;
   }
 
-  @When("^a client makes a GET request to (.+)$")
-  public void a_client_makes_a_GET_request_to_echo(String uri) throws Throwable {
+  @When("^a client makes a ([A-Z]+) request to (.+)$")
+  public void a_client_makes_a_HEAD_request_to(String method, String uri) throws Throwable {
     this.world.requestUri = uri;
     String urlString = String.format("http://localhost:%d%s", PORT, uri);
     URL url = new URL(urlString);
     this.world.con = (HttpURLConnection) url.openConnection();
+    this.world.con.setRequestMethod(method);
   }
   
 }

--- a/src/test/java/StepDefinitions/ResponseStepDefs.java
+++ b/src/test/java/StepDefinitions/ResponseStepDefs.java
@@ -58,6 +58,12 @@ public class ResponseStepDefs {
     assertTrue(Arrays.equals(expectedMessageBody, messageBody));
   }
 
+  @Then("^the server should not respond with a message body$")
+  public void the_server_should_not_respond_with_a_message_body() throws Throwable {
+    String messageBody = StepDefsUtil.readMessageBody(this.world.con);  
+    assertEquals("", messageBody);
+  }
+
   private String getFormattedTime(String timeFormat) {
     DateFormat dateFormat = new SimpleDateFormat(timeFormat);
     return dateFormat.format(new Date());

--- a/src/test/resources/features/echo.feature
+++ b/src/test/resources/features/echo.feature
@@ -6,3 +6,8 @@ Scenario: GET request to /echo
   Then the server should respond with status code 200 OK 
   And the server should respond with the current time in hh:mm:ss 
  
+  Scenario: HEAD request to /echo
+    When a client makes a HEAD request to /echo
+    Then the server should respond with status code 200 OK 
+    And the server should respond with the header Content-Type text/plain
+    And the server should not respond with a message body

--- a/src/test/resources/features/imageNegotiation.feature
+++ b/src/test/resources/features/imageNegotiation.feature
@@ -8,3 +8,9 @@ Scenario: The image file exists
 Scenario: The image file does not exist
   When a client makes a GET request to /does-not-exist.jpg
   Then the server should respond with status code 404 Not Found
+
+Scenario: HEAD request to an existing image file
+  When a client makes a HEAD request to /cat-and-dog.jpg
+  Then the server should respond with status code 200 OK 
+  And the server should respond with the header Content-Type image/jpeg
+  And the server should not respond with a message body

--- a/src/test/resources/features/root.feature
+++ b/src/test/resources/features/root.feature
@@ -8,3 +8,9 @@ Feature: Root Handler
   Scenario: GET request to any other endpoint
     When a client makes a GET request to /any/other/endpoint
     Then the server should respond with status code 404 Not Found
+
+  Scenario: HEAD request to root
+    When a client makes a HEAD request to /
+    Then the server should respond with status code 200 OK 
+    And the server should respond with the header Content-Type text/html
+    And the server should not respond with a message body

--- a/src/test/resources/features/textNegotiation.feature
+++ b/src/test/resources/features/textNegotiation.feature
@@ -8,3 +8,9 @@ Scenario: The text file exists
 Scenario: The text file does not exist
   When a client makes a GET request to /does-not-exist.txt
   Then the server should respond with status code 404 Not Found
+
+Scenario: HEAD request to an existing text file
+  When a client makes a HEAD request to /sample-text.txt
+  Then the server should respond with status code 200 OK 
+  And the server should respond with the header Content-Type text/plain
+  And the server should not respond with a message body


### PR DESCRIPTION
## `Handler`s
All `Handler`s ( `EchoHandler`, `RootHandler`, and `FileHandler`) can now respond to HEAD requests. However, there is a lot of repeated code within each `Handler`. Specifically, the `#buildGetRequest()` and `#buildHeadRequest()` methods are identical except that the latter does not make use of the `#messageBody()` builder method.  

I've tried to dry out some of the `Handler`s by having just one `Builder` at the end of `#generateResponse()`, and having each case individually determine the different response attributes, but that approach also results in a lot of repeated code across different helper methods. 

## HeaderStepDefs 
In order to continue to separate Step Defintions into their domain models, I created the `HeaderStepDefs` class. It currently includes just the method below. 
```Java 
  @Then("^the server should respond with the header (.+) (.+)$")
  public void the_server_should_respond_with_the_header(String field, String expectedValue) throws Throwable {
    assertEquals(expectedValue, this.world.con.getHeaderField(field));
  }
```
Any feature step that requires assertions on a header field and value use this method. This might be a Cucumber-specific question, but when it comes to testing headers, I'm not sure whether I should be adding steps to existing scenarios (as I'm currently doing) or if I should be creating new features that check only for headers. For example, this is one of my `textNegotiation.feature` scenarios: 

```Gherkin
Scenario: HEAD request to an existing text file
  When a client makes a HEAD request to /sample-text.txt
  Then the server should respond with status code 200 OK 
  And the server should respond with the header Content-Type text/plain
  And the server should not respond with a message body
```
I could see these scenarios becoming longer as I add on features to the server, but I'm not sure how I should be separating features. If I had a `header.feature` scenario that ran assertions only on headers, then it might fail to notice that a HEAD request returned a message body. 