### PR TITLE
Fix Bug That Caused 404 Response When Requesting URI With Spaces

### DIFF
--- a/src/main/java/Request/RequestLine.java
+++ b/src/main/java/Request/RequestLine.java
@@ -12,7 +12,7 @@ public class RequestLine {
       String[] httpVersion = splitRequestLine[2].split("/");
   
       this.method = method;
-      this.uri = uri;
+      this.uri = sanitizeUri(uri);
       this.version = httpVersion[1];
     } catch (ArrayIndexOutOfBoundsException e) {
       throw new BadRequestException("Could not parse request line.");
@@ -30,5 +30,9 @@ public class RequestLine {
   public String getHTTPVersion() {
     return this.version;
   }
-  
+
+  private String sanitizeUri(String uri) {
+    String encodedSpace = "%20";
+    return uri.replace(encodedSpace, " ");
+  }
 }

--- a/src/test/java/Handler/EchoHandlerTest.java
+++ b/src/test/java/Handler/EchoHandlerTest.java
@@ -10,13 +10,7 @@ public class EchoHandlerTest {
   
   @Test 
   public void returnsCurrentTime(){ 
-    Request request = new Request.Builder()
-                                 .method("GET")
-                                 .uri("/echo")
-                                 .version("1.1")
-                                 .build();  
-                                 
-
+    Request request = TestUtil.buildRequestToUri("GET", "/echo");
     String expectedMessageBody = createExpectedMessageBody();
     Response response = handler.generateResponse(request);
     String stringifiedMessageBody = new String(response.getMessageBody());
@@ -25,15 +19,10 @@ public class EchoHandlerTest {
 
   @Test 
   public void returnsOnlyHeadersForHeadRequest() {
-    Request request = new Request.Builder()
-                                 .method("HEAD")
-                                 .uri("/echo")
-                                 .version("1.1")
-                                 .build();   
-                                 
+    Request request = TestUtil.buildRequestToUri("HEAD", "/echo");
     Response response = handler.generateResponse(request);
     String messageBody = new String(response.getMessageBody());
-    assertEquals(200, response.getStatusCode()); 
+    assertEquals(HttpStatusCode.OK, response.getStatusCode()); 
     assertEquals("", messageBody); 
   }
 
@@ -46,4 +35,5 @@ public class EchoHandlerTest {
     DateFormat dateFormat = new SimpleDateFormat(TIME_FORMAT);
     return dateFormat.format(new Date());
   }
+  
 }

--- a/src/test/java/Handler/FileHandlerTest.java
+++ b/src/test/java/Handler/FileHandlerTest.java
@@ -9,8 +9,7 @@ public class FileHandlerTest {
   private final static String TEXT_FILE_URI = "/text-file.txt";
   
   private static Handler handler;
-  private Request requestToExistingFile = buildRequestToExistingFile();
-  private Request requestToNonexistentFile = buildRequestToNonexistentFile();
+  private Request requestToExistingFile = TestUtil.buildRequestToUri("GET", TEXT_FILE_URI);
 
   @BeforeClass
   public static void setUp() throws IOException, NonexistentDirectoryException {
@@ -25,7 +24,8 @@ public class FileHandlerTest {
   
   @Test  
   public void returns404IfFileDoesNotExist() {  
-    Response response = handler.generateResponse(this.requestToNonexistentFile); 
+    Request request = TestUtil.buildRequestToUri("GET", NONEXISTENT_FILE_URI);
+    Response response = handler.generateResponse(request); 
     assertEquals(404, response.getStatusCode()); 
   } 
 
@@ -44,32 +44,11 @@ public class FileHandlerTest {
 
   @Test 
   public void returnsOnlyHeadersForHeadRequest() {
-    Request request = new Request.Builder()
-                                 .method("HEAD")
-                                 .uri("/text-file.txt")
-                                 .version("1.1")
-                                 .build();   
-                                 
+    Request request = TestUtil.buildRequestToUri("HEAD", TEXT_FILE_URI);
     Response response = handler.generateResponse(request);
     String messageBody = new String(response.getMessageBody());
     assertEquals(200, response.getStatusCode()); 
     assertEquals("", messageBody); 
   }
-
-  private static Request buildRequestToNonexistentFile() { 
-  return new Request.Builder() 
-                    .method("GET") 
-                    .uri(NONEXISTENT_FILE_URI) 
-                    .version("1.1") 
-                    .build(); 
-  } 
-
-  private static Request buildRequestToExistingFile() { 
-  return new Request.Builder() 
-                    .method("GET") 
-                    .uri(TEXT_FILE_URI) 
-                    .version("1.1") 
-                    .build(); 
-  } 
 
 }

--- a/src/test/java/Handler/RootHandlerTest.java
+++ b/src/test/java/Handler/RootHandlerTest.java
@@ -23,45 +23,30 @@ public class RootHandlerTest {
     
   @Test 
   public void returneContentsOfDirectoryAsHtml() {
-    Request request = new Request.Builder()
-                                 .method("GET")
-                                 .uri("/")
-                                 .version("1.1")
-                                 .build();   
+    Request request = TestUtil.buildRequestToUri("GET", "/");
 
     String[] files = { TestUtil.removeLeadingParenthesesFromUri(HTML_FILE_URI),
                        TestUtil.removeLeadingParenthesesFromUri(TEXT_FILE_URI) 
-                    };
+                     };
     String expectedHtml = TestUtil.createRootHtmlFromFileNames(files);
-    // String expectedHtml = TestUtil.createRootHtmlFromUris(uris);
     String messageBody = new String(handler.generateResponse(request).getMessageBody());
     assertEquals(expectedHtml, messageBody);
   }
   
   @Test 
-  public void returnsOnlyHeadersForHeadRequest() {
-    Request request = new Request.Builder()
-                                 .method("HEAD")
-                                 .uri("/")
-                                 .version("1.1")
-                                 .build();   
-                                 
+  public void returnsOnlyHeadersForHeadRequest() {  
+    Request request = TestUtil.buildRequestToUri("HEAD", "/");
     Response response = handler.generateResponse(request);
     String messageBody = new String(response.getMessageBody());
-    assertEquals(200, response.getStatusCode()); 
+    assertEquals(HttpStatusCode.OK, response.getStatusCode()); 
     assertEquals("", messageBody); 
   }
   
   @Test
   public void return405MethodNotAllowed() {
-    Request request = new Request.Builder()
-                                 .method("POST")
-                                 .uri("/")
-                                 .version("1.1")
-                                 .build();                           
-
+    Request request = TestUtil.buildRequestToUri("POST", "/");
     Response response = handler.generateResponse(request);
-    assertEquals(405, response.getStatusCode()); 
+    assertEquals(HttpStatusCode.METHOD_NOT_ALLOWED, response.getStatusCode()); 
     assertEquals("Method Not Allowed", response.getReasonPhrase()); 
   }
 

--- a/src/test/java/Request/RequestLineTest.java
+++ b/src/test/java/Request/RequestLineTest.java
@@ -34,8 +34,14 @@ public class RequestLineTest {
   }
 
   @Test 
-  public void getsURI() {
+  public void getsUri() {
     assertEquals("/uri/path", requestLine.getURI());
+  }
+
+  @Test 
+  public void getsUriWithSpaces() throws BadRequestException {
+    RequestLine requestLineWithSpacesInUri = new RequestLine("GET /file%20with%20spaces.txt HTTP/1.1");
+    assertEquals("/file with spaces.txt", requestLineWithSpacesInUri.getURI());
   }
 
   @Test 

--- a/src/test/java/util/TestUtil.java
+++ b/src/test/java/util/TestUtil.java
@@ -1,5 +1,13 @@
 public class TestUtil {
 
+  public static Request buildRequestToUri(String method, String uri) {
+    return new Request.Builder() 
+                      .method(method) 
+                      .uri(uri) 
+                      .version("1.1") 
+                      .build(); 
+  }
+  
   public static String createRootHtmlFromFileNames(String[] fileNames) {
     String expectedHtml = "";
     for (String fileName : fileNames) {
@@ -10,18 +18,6 @@ public class TestUtil {
 
     return expectedHtml;
   }
-  
-  // public static String createRootHtmlFromUris(String[] uris) {
-  //   String expectedHtml = "";
-  //   for (String uri : uris) {
-  //     String fileName = TestUtil.removeLeadingParenthesesFromUri(uri);
-  //     expectedHtml += String.format(
-  //       "<a href=\"/%s\">%s</a>" + 
-  //       "<br>", fileName, fileName);
-  //   }
-
-  //   return expectedHtml;
-  // }
 
   public static String removeLeadingParenthesesFromUri(String uri) {
     int idxOfFirstCharacter = 1;

--- a/src/test/resources/features/textNegotiation.feature
+++ b/src/test/resources/features/textNegotiation.feature
@@ -5,6 +5,11 @@ Scenario: The text file exists
   Then the server should respond with status code 200 OK 
   And the server should respond with a message body of "This is a sample text file."
 
+Scenario: The text file exists and contains spaces in its name 
+  When a client makes a GET request to /file%20with%20spaces.txt
+  Then the server should respond with status code 200 OK 
+  And the server should respond with a message body of "The title of this text file has spaces."
+
 Scenario: The text file does not exist
   When a client makes a GET request to /does-not-exist.txt
   Then the server should respond with status code 404 Not Found


### PR DESCRIPTION
This PR fixes a bug where GET requests to files whose names included spaces resulted in a `404 Not Found` response. This response occurred because the `RequestLineParser` would receive a URI with [HTML encoded spaces](http://krypted.com/utilities/html-encoding-reference/), and the `#existsInStore()` method in `Directory` would search for the file with the encoded spaces. For example, the status line of a GET request to a file name with spaces would arrive as `GET /file%20%with%20spaces.txt HTTP/1.1`. If `file with spaces.txt` exists inside the `Directory`,  a call to `existsInStore(/file%20%with%20spaces.txt)` would return `false`.

## RequestLineParser
To fix the issue described above, I've updated the `RequestLineParser` class with a `sanitizeUri(Stringuri)` method, which simply replaces `%20` with a space. In the future, if I need to replace more encoded characters, it would make sense move the logic for decoding into a separate class. 

## TestUtil
While determining precisely where to inject the fix to the bug, I encountered some repeated code across the tests for each `Handler`. Specifically, `FileHandlerTest`, `RootHandlerTest`, and `EchoHandlerTest` all built `Request`s similar to the code below. 
```Java
Request request = new Request.Builder()
                             .method("GET")	
                             .uri("/echo")	
                             .version("1.1")	
                             .build(); 
```
To avoid repeating nearly the same piece of code every time, I abstracted the logic into the following method in the `TestUtil` class.

```Java
public static Request buildRequestToUri(String method, String uri) {
  return new Request.Builder() 
                    .method(method) 
                    .uri(uri) 
                    .version("1.1") 
                    .build(); 
}
```