### PR TITLE
Handle DELETE requests

### DIFF
--- a/src/main/java/DataStore/DataStore.java
+++ b/src/main/java/DataStore/DataStore.java
@@ -5,5 +5,6 @@ public interface DataStore {
   public byte[] readFile(String uri);
   public String getFileType(String uri);
   public void postFile (String uri, byte[] content);
+  public boolean deleteFile(String uri);
 
 }

--- a/src/main/java/DataStore/Directory.java
+++ b/src/main/java/DataStore/Directory.java
@@ -11,12 +11,12 @@ import java.nio.file.Files;
 public class Directory implements DataStore {
   private static final String DEFAULT_FILE_TYPE = "application/octet-stream";
   private static final Map<String, String> MIME_TYPES = Map.ofEntries(
-      Map.entry("gif", "image/gif"),
-      Map.entry("html", "text/html"),
-      Map.entry("jpg", "image/jpeg"),
-      Map.entry("jpeg", "image/jpeg"),
-      Map.entry("png", "image/png"),
-      Map.entry("txt", "text/plain")
+    Map.entry("gif", "image/gif"),
+    Map.entry("html", "text/html"),
+    Map.entry("jpg", "image/jpeg"),
+    Map.entry("jpeg", "image/jpeg"),
+    Map.entry("png", "image/png"),
+    Map.entry("txt", "text/plain")
   );
   
   private File directory;
@@ -72,6 +72,11 @@ public class Directory implements DataStore {
       System.err.println("IOException failed inside Directory");
       System.err.println(e);
     }
+  }
+  
+  public boolean deleteFile(String uri) {
+    File file = new File(this.directoryPath + uri);
+    return file.delete();
   }
   
 }

--- a/src/main/java/Handler/FileHandler.java
+++ b/src/main/java/Handler/FileHandler.java
@@ -9,16 +9,28 @@ import java.io.UnsupportedEncodingException;
   
   public Response generateResponse(Request request) { 
     String uri = request.getURI();
+
+    if (!this.store.existsInStore(uri)) {
+      return buildNotFoundResponse(uri);
+    }
      
     switch (request.getMethod()) { 
       case "HEAD":  
         return buildHeadResponse(uri); 
       case "GET":  
         return buildGetResponse(uri); 
+      case "DELETE":  
+        return this.store.deleteFile(uri) ? buildDeleteResponse() : buildInternalServerErrorResponse();
       default:  
         return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED) 
                            .build(); 
     } 
+  }
+
+  private Response buildNotFoundResponse(String uri) {
+    return new Response.Builder(HttpStatusCode.NOT_FOUND)
+                       .messageBody(buildNotFoundMessage(uri))
+                       .build();
   }
 
   private Response buildHeadResponse(String uri) {
@@ -41,6 +53,16 @@ import java.io.UnsupportedEncodingException;
                        .messageBody(messageBody)
                        .setHeader(MessageHeader.CONTENT_LENGTH, contentLength)
                        .setHeader(MessageHeader.CONTENT_TYPE, contentType)
+                       .build();
+  }
+  
+  private Response buildDeleteResponse() {
+    return new Response.Builder(HttpStatusCode.NO_CONTENT)
+                       .build();
+  }
+
+  private Response buildInternalServerErrorResponse() {
+    return new Response.Builder(HttpStatusCode.INTERNAL_SERVER_ERROR)
                        .build();
   }
 

--- a/src/main/java/Response/HttpStatusCode.java
+++ b/src/main/java/Response/HttpStatusCode.java
@@ -3,21 +3,26 @@ import java.util.Map;
 public class HttpStatusCode {
   public static final int OK = 200;
   public static final int CREATED = 201;
+  public static final int NO_CONTENT = 204;
   public static final int SEE_OTHER = 303;
   public static final int BAD_REQUEST= 400;
   public static final int NOT_FOUND = 404;
   public static final int METHOD_NOT_ALLOWED = 405;
+  public static final int INTERNAL_SERVER_ERROR = 500;
 
   private static final Map<Integer, String> messages = Map.ofEntries(
-      Map.entry(BAD_REQUEST, "Bad Request"),
-      Map.entry(CREATED, "Created"),
-      Map.entry(OK, "OK"),
-      Map.entry(METHOD_NOT_ALLOWED, "Method Not Allowed"),
-      Map.entry(NOT_FOUND, "Not Found"),
-      Map.entry(SEE_OTHER, "See Other")
+    Map.entry(BAD_REQUEST, "Bad Request"),
+    Map.entry(CREATED, "Created"),
+    Map.entry(INTERNAL_SERVER_ERROR, "Internal Server Error"),
+    Map.entry(OK, "OK"),
+    Map.entry(METHOD_NOT_ALLOWED, "Method Not Allowed"),
+    Map.entry(NO_CONTENT, "No Content"),
+    Map.entry(NOT_FOUND, "Not Found"),
+    Map.entry(SEE_OTHER, "See Other")
   );
 
   public static final String getReasonPhrase(int statusCode) {
     return messages.get(statusCode);
   }
+
 }

--- a/src/test/java/DataStore/DirectoryTest.java
+++ b/src/test/java/DataStore/DirectoryTest.java
@@ -2,6 +2,7 @@ import java.io.File;
 import java.io.IOException; 
 import java.util.Arrays;
 import static org.junit.Assert.assertEquals; 
+import static org.junit.Assert.assertFalse; 
 import static org.junit.Assert.assertTrue; 
 import org.junit.BeforeClass; 
 import org.junit.Rule;
@@ -11,20 +12,21 @@ import org.junit.Test;
 public class DirectoryTest {
   private final static String EMPTY_TEXT_FILE_URI = "/empty-file.txt";
   private final static String NONEXISTENT_FILE_URI = "/does-not-exist.txt";
+  private final static String TEMP_DIRECTORY_PATH = System.getProperty("user.dir") + "/src/test/java/DataStore/TestDirectory";
   private final static String TEXT_FILE_CONTENT = "This is a sample text file.";
   private final static String TEXT_FILE_URI = "/text-file.txt";
+  private final static String TO_BE_DELETED_URI = "/to-be-deleted.txt";
 
   private static Directory directory;
 
   @BeforeClass
   public static void setUp() throws IOException, NonexistentDirectoryException {
-    String tempDirectoryPath = System.getProperty("user.dir") + "/src/test/java/DataStore/TestDirectory";
-
-    TempDirectory temp = new TempDirectory(tempDirectoryPath);
+    TempDirectory temp = new TempDirectory(TEMP_DIRECTORY_PATH);
     temp.createEmptyFile(EMPTY_TEXT_FILE_URI);
+    temp.createEmptyFile(TO_BE_DELETED_URI);
     temp.createFileWithContent(TEXT_FILE_URI, TEXT_FILE_CONTENT);
 
-    directory = new Directory(tempDirectoryPath); 
+    directory = new Directory(TEMP_DIRECTORY_PATH); 
   }
   
   @Rule
@@ -77,6 +79,15 @@ public class DirectoryTest {
 
     assertTrue(file.exists()); 
     file.delete();
+  }
+
+  @Test 
+  public void returnsTrueIfFileWasDeleted() {
+    boolean wasDeleted = directory.deleteFile(TO_BE_DELETED_URI);
+    File shouldHaveBeenDeleted = new File(TEMP_DIRECTORY_PATH + TO_BE_DELETED_URI); 
+
+    assertTrue(wasDeleted);
+    assertFalse(shouldHaveBeenDeleted.exists());
   }
   
 }

--- a/src/test/java/Handler/FileHandlerTest.java
+++ b/src/test/java/Handler/FileHandlerTest.java
@@ -1,4 +1,7 @@
 import java.io.IOException; 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import static org.junit.Assert.assertEquals; 
 import org.junit.BeforeClass; 
 import org.junit.Test; 
@@ -7,19 +10,15 @@ public class FileHandlerTest {
   private final static String NONEXISTENT_FILE_URI = "/does-not-exist.txt";
   private final static String TEXT_FILE_CONTENT = "This is a sample text file.";
   private final static String TEXT_FILE_URI = "/text-file.txt";
+  private final static String TO_BE_DELETED_URI = "/to-be-deleted.txt";
   
   private static Handler handler;
   private Request requestToExistingFile = TestUtil.buildRequestToUri("GET", TEXT_FILE_URI);
 
   @BeforeClass
   public static void setUp() throws IOException, NonexistentDirectoryException {
-    String tempDirectoryPath = System.getProperty("user.dir") + "/src/test/java/Handler/TestDirectory";
-
-    TempDirectory temp = new TempDirectory(tempDirectoryPath);
-    temp.createFileWithContent(TEXT_FILE_URI, TEXT_FILE_CONTENT);
-
-    Directory directory = new Directory(tempDirectoryPath); 
-    handler = new FileHandler(directory); 
+    DataStore mockDirectory = setUpMockDirectory();
+    handler = new FileHandler(mockDirectory); 
   }
   
   @Test  
@@ -49,6 +48,46 @@ public class FileHandlerTest {
     String messageBody = new String(response.getMessageBody());
     assertEquals(200, response.getStatusCode()); 
     assertEquals("", messageBody); 
+  }
+
+  @Test 
+  public void returns204ForDeleteRequest() {
+    Request request = TestUtil.buildRequestToUri("DELETE", TO_BE_DELETED_URI);
+    Response response = handler.generateResponse(request);
+    String messageBody = new String(response.getMessageBody());
+    assertEquals(204, response.getStatusCode()); 
+  }
+
+  private static DataStore setUpMockDirectory() throws NonexistentDirectoryException {
+    List<String> subdirectories = setUpMockSubdirectories();
+    List<String> files = setUpMockFiles();   
+    Map<String, String> fileContents = setUpMockFileContents();
+    Map<String, String> fileTypes = setUpMockFileContents();
+    return new MockDirectory(subdirectories, files, fileContents, fileTypes);
+  }
+
+  private static List<String> setUpMockSubdirectories() {
+    ArrayList<String> subdirectories = new ArrayList<String>();
+    return subdirectories;
+  }
+
+  private static List<String> setUpMockFiles() {
+    ArrayList<String> files = new ArrayList<String>();
+    files.add(TEXT_FILE_URI);
+    files.add(TO_BE_DELETED_URI);
+    return files;
+  }
+
+  private static Map<String, String> setUpMockFileContents() {
+    return Map.ofEntries(
+      Map.entry(TEXT_FILE_URI, TEXT_FILE_CONTENT)
+    );
+  }
+
+  private static Map<String, String> setUpMockFileTypes() {
+    return Map.ofEntries(
+      Map.entry(TEXT_FILE_URI, TEXT_FILE_CONTENT)
+    );
   }
 
 }

--- a/src/test/java/Mock/MockDirectory.java
+++ b/src/test/java/Mock/MockDirectory.java
@@ -1,0 +1,44 @@
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MockDirectory implements DataStore {
+  private List<String> subdirectories;
+  private List<String> files;   
+  private Map<String, String> fileContents;
+  private Map<String, String> fileTypes;
+  
+  public MockDirectory(List<String> subdirectories, List<String> files, Map fileContents, Map fileTypes) throws NonexistentDirectoryException {
+    this.subdirectories = subdirectories;
+    this.files = files;
+    this.fileContents = fileContents;
+    this.fileTypes = fileTypes;
+  }
+  
+  public String[] listContent() {
+    String[] content = { "content" };
+    return content; 
+  }
+
+  public Boolean existsInStore(String uri) {
+    return this.subdirectories.contains(uri) || this.files.contains(uri);
+  }
+
+  public byte[] readFile(String uri) {
+    String content = fileContents.get(uri);
+    return content.getBytes();
+  }
+
+  public String getFileType(String uri) {
+    return this.fileTypes.get(uri);
+  }
+
+  public void postFile (String uri, byte[] content) {
+    this.files.add(uri);
+  }
+
+  public boolean deleteFile(String uri) {
+    return this.files.remove(uri);
+  }
+
+}

--- a/src/test/java/StepDefinitions/DirectoryStepDefs.java
+++ b/src/test/java/StepDefinitions/DirectoryStepDefs.java
@@ -1,0 +1,21 @@
+import cucumber.api.java.en.Given;
+import cucumber.api.PendingException;
+import java.io.File;
+import static org.junit.Assert.assertFalse;
+
+public class DirectoryStepDefs {
+  private final static String TEST_DIRECTORY_PATH = System.getProperty("TEST_DIRECTORY_PATH"); 
+
+  @Given("^a file with the name (.+) exists in the root directory$")
+  public void a_file_with_the_name_exists_in_the_root_directory(String fileName) throws Throwable {
+    File file = new File(TEST_DIRECTORY_PATH + "/" + fileName);
+    file.createNewFile();
+  }
+
+  @Given("^a file with the name (.+) does not exist in the root directory$")
+  public void a_file_with_the_name_does_not_exist_in_the_root_directory(String fileName) throws Throwable {
+    File file = new File(TEST_DIRECTORY_PATH + "/" + fileName);
+    assertFalse(file.exists());
+  }
+  
+}

--- a/src/test/resources/features/delete.feature
+++ b/src/test/resources/features/delete.feature
@@ -1,0 +1,16 @@
+Feature: Delete a resource
+
+Scenario: DELETE request to an existing resource 
+  Given a file with the name will-be-deleted.txt exists in the root directory
+  When a client makes a DELETE request to /will-be-deleted.txt
+  Then the server should respond with status code 204 No Content 
+  
+Scenario: DELETE request to a resource that has been deleted 
+  When a client makes a DELETE request to /will-be-deleted.txt
+  Then the server should respond with status code 404 Not Found 
+  
+Scenario: DELETE request to a resource that does not exist
+  Given a file with the name does-not-exist.txt does not exist in the root directory
+  When a client makes a DELETE request to /does-not-exist.txt
+  Then the server should respond with status code 404 Not Found 
+  


### PR DESCRIPTION
## FileHandler
The `FileHandler`'s `#generateResponse` method adds a new `case` to the `switch(request.getMethod())` statement. When a DELETE request comes in, it delegates the deletion of the file to it's `store`. Since the `#deleteFile` method returns a boolean, it builds a response with `204 No Content` after a successful deletion and a `500 Internal Server Error` if it cannot delete that file. 

Since I haven't merged `ft/directory-navigation`, I added the following piece of code to the beginning of the `#generateResponse` method. The `ft/directory-navigation` branch creates and sets `NotFoundHandler` as the default `Handler` when no custom route for a request is found, so I will remove this piece of code once that branch gets merged in. 

```Java
if (!this.store.existsInStore(uri)) {
  return buildNotFoundResponse(uri);
}
```

## FileHandlerTest
This class makes use of the new `MockDirectoryClass` rather than relying on a `TemporaryDirectory` and an actual implementation of the `Directory` class as a `DataStore`. 

## MockDirectory
To avoid coupling certain test classes to the `Directory` class and to a temporary directory that creates and deletes files, I created a `MockDirectory`. Rather than creating real directories and files, the constructor takes a `subdirectories` List, `files` List, `fileContents` Map, and `fileTypes` Map. `MockDirectory`'s methods read and manipulate those data structures to return predictable values. 

Only the `#listContent` methods lacks customization. Currently only `FileHandler` uses `MockDirectory`. Since this feature still relies on the `DataStore` interface, I had to implement this method in order to compile. I wanted to get your input before integrating this mock into the other tests classes that use a `TempDirectory` (specifically `FormHandlerTest`, `RootHandlerTest`, and `LoggerTest`). 

## DataStore & Directory  
The `DataStore` interface includes a new method: `#deleteFile(String uri)`, which returns a boolean. `Directory` implements this feature. 

## DirectoryStepDefs
I was having trouble making a gradle task that would create a text file which would be deleted in the implementation of the`When a client makes a DELETE request to /will-be-deleted.txt` step. I kept getting a `Could not copy file` error. Instead of creating the file through a gradle task, I now create the file with the implementation of `Given a file with the name will-be-deleted.txt exists in the root directory` in `DirectoryStepDefs`. 


