### PR TITLE
Create a Resource through POST Request

### DIFF
--- a/src/main/java/Directory.java
+++ b/src/main/java/Directory.java
@@ -68,15 +68,17 @@ public class Directory {
     return MIME_TYPES.getOrDefault(extension, DEFAULT_FILE_TYPE);
   }
   
-  public void createFileWithContent(String uri, byte[] content) {
+  public boolean createFileWithContent(String uri, byte[] content) {
     try {
       File file = new File(this.directoryPath + uri);
       file.createNewFile();
       FileOutputStream outputStream = new FileOutputStream(file.getAbsolutePath());
       outputStream.write(content);
+      return file.exists();
     } catch(IOException e) {
       System.err.println("IOException failed inside Directory");
       System.err.println(e);
+      return false;
     }
   }
 

--- a/src/main/java/Handler/FormHandler.java
+++ b/src/main/java/Handler/FormHandler.java
@@ -1,10 +1,11 @@
 import java.io.File;
-import java.io.IOException; 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
   
 public class FormHandler implements Handler {   
+  private final static String DESTINATION_DIRECTORY_URI = "/POSTed";
+  private final static String POSTED_FILE_EXTENSION = ".txt";
+  
   private Directory directory;
   
   public FormHandler(Directory directory) {
@@ -25,7 +26,7 @@ public class FormHandler implements Handler {
 
   private Response buildPostResponse(Request request) {
     try {
-      String uri = "/POSTed/" + randomFileName() + ".txt";
+      String uri = DESTINATION_DIRECTORY_URI + "/" + Util.createRandomFileName(POSTED_FILE_EXTENSION);
       byte[] content = createFileContent(request);
       directory.createFileWithContent(uri, content);
       return new Response.Builder(HttpStatusCode.SEE_OTHER)
@@ -35,11 +36,6 @@ public class FormHandler implements Handler {
       return new Response.Builder(HttpStatusCode.BAD_REQUEST)
                          .build();
     }
-  }
-
-   private String randomFileName() {
-    int rand = new Random().nextInt(999999999) + 100000000;
-    return Integer.toString(rand);
   }
 
   private byte[] createFileContent(Request request) throws ArrayIndexOutOfBoundsException {

--- a/src/main/java/Handler/FormHandler.java
+++ b/src/main/java/Handler/FormHandler.java
@@ -24,12 +24,17 @@ public class FormHandler implements Handler {
   }
 
   private Response buildPostResponse(Request request) {
+    try {
       String uri = "/POSTed/" + randomFileName() + ".txt";
       byte[] content = createFileContent(request);
       directory.createFileWithContent(uri, content);
       return new Response.Builder(HttpStatusCode.SEE_OTHER)
-                         .setHeader("Location", uri)
+                         .setHeader(MessageHeader.LOCATION, uri)
                          .build();
+    } catch(ArrayIndexOutOfBoundsException e) {
+      return new Response.Builder(HttpStatusCode.BAD_REQUEST)
+                         .build();
+    }
   }
 
    private String randomFileName() {
@@ -37,15 +42,35 @@ public class FormHandler implements Handler {
     return Integer.toString(rand);
   }
 
-  private byte[] createFileContent(Request request) {
+  private byte[] createFileContent(Request request) throws ArrayIndexOutOfBoundsException {
     String content =  "Thank you for submitting the following data:\n";
-    HashMap<String, String> messageBody = request.getMessageBody();
-    for (Map.Entry<String, String> entry : messageBody.entrySet()) {
+    HashMap<String, String> bodyKeyValPairs = extractKeyValPairsFromBody(request.getBody());
+    content += stringifyKeyValPairs(bodyKeyValPairs);
+    return content.getBytes();
+  }
+  
+  private HashMap<String, String> extractKeyValPairsFromBody(String body) throws ArrayIndexOutOfBoundsException {
+    HashMap<String, String> keyValPairs = new HashMap<String, String>();
+    String[] splitBody = body.split("&");
+    for (String keyValPair : splitBody) {
+      String[] splitKeyValPair = keyValPair.split("=");
+      String key = splitKeyValPair[0];
+      String val = splitKeyValPair[1];
+      keyValPairs.put(key, val);
+    }
+    
+    return keyValPairs;
+  }
+
+  private String stringifyKeyValPairs(HashMap<String, String> keyValPairs) {
+    String result = "";
+    for (Map.Entry<String, String> entry : keyValPairs.entrySet()) {
       String key = entry.getKey();
       String value = entry.getValue();
-      content += key + " : " + value + "\n";
+      result += key + ": " + value + "\n";
     }
-     return content.getBytes();
+
+    return result;
   }
 
 }

--- a/src/main/java/Handler/PeopleHandler.java
+++ b/src/main/java/Handler/PeopleHandler.java
@@ -2,7 +2,6 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Random;
 
 public class PeopleHandler implements Handler {
   private final static String[] SUPPORTED_MEDIA_TYPES = { 
@@ -40,14 +39,9 @@ public class PeopleHandler implements Handler {
     String contentType = request.getHeader(MessageHeader.CONTENT_TYPE);
     String extension = MimeType.getExtension(contentType);
     byte[] content = request.getBody().getBytes();
-    String uri = "/people/" + randomFileName(extension);
+    String uri = "/people/" + Util.createRandomFileName(extension);
     this.directory.createFileWithContent(uri, content);
     return uri;
-  }
-
-  private String randomFileName(String extension) {
-    int rand = new Random().nextInt(999999999) + 100000000;
-    return Integer.toString(rand) + extension;
   }
 
   private Response buildPostResponse(String seeOtherUri) {

--- a/src/main/java/Handler/PeopleHandler.java
+++ b/src/main/java/Handler/PeopleHandler.java
@@ -1,0 +1,64 @@
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+
+public class PeopleHandler implements Handler {
+  private final static String[] SUPPORTED_MEDIA_TYPES = { 
+    MimeType.JSON, 
+    MimeType.PLAIN_TEXT
+  };
+
+  private Directory directory;
+
+  public PeopleHandler(Directory directory) {
+    this.directory = directory;
+  }
+
+  public Response generateResponse(Request request) {
+    switch (request.getMethod()) { 
+      case "POST":  
+        return handlePostRequest(request); 
+      default:  
+        return new Response.Builder(HttpStatusCode.METHOD_NOT_ALLOWED) 
+                           .build(); 
+    }    
+  }
+
+  private Response handlePostRequest(Request request) {
+    String contentType = request.getHeader(MessageHeader.CONTENT_TYPE);
+    if (Arrays.asList(SUPPORTED_MEDIA_TYPES).contains(contentType)) {
+      String seeOtherUri = createFile(request);
+      return buildPostResponse(seeOtherUri);
+    } else {
+      return buildUnsupportedMediaTypeResponse();
+    }
+  }
+
+  private String createFile(Request request) {
+    String contentType = request.getHeader(MessageHeader.CONTENT_TYPE);
+    String extension = MimeType.getExtension(contentType);
+    byte[] content = request.getBody().getBytes();
+    String uri = "/people/" + randomFileName(extension);
+    this.directory.createFileWithContent(uri, content);
+    return uri;
+  }
+
+  private String randomFileName(String extension) {
+    int rand = new Random().nextInt(999999999) + 100000000;
+    return Integer.toString(rand) + extension;
+  }
+
+  private Response buildPostResponse(String seeOtherUri) {
+    return new Response.Builder(HttpStatusCode.CREATED)
+                       .setHeader(MessageHeader.LOCATION, seeOtherUri)
+                       .build();
+  }
+
+  private Response buildUnsupportedMediaTypeResponse() {
+    return new Response.Builder(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE)
+                      .build();
+  }
+
+}

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -61,7 +61,7 @@ public class Main {
     routes.put("/", new DirectoryHandler(directory));
     routes.put("/echo", new EchoHandler());
     routes.put("/api/form", new FormHandler(directory));
- 
+    routes.put("/api/people", new PeopleHandler(directory));
     return routes;
   }
 

--- a/src/main/java/MimeType.java
+++ b/src/main/java/MimeType.java
@@ -1,0 +1,16 @@
+import java.util.Map;
+
+public class MimeType {
+  public final static String JSON = "application/json";
+  public final static String PLAIN_TEXT = "text/plain";
+
+  private static final Map<String, String> extensions = Map.ofEntries(
+    Map.entry(JSON, ".json"),
+    Map.entry(PLAIN_TEXT, ".txt")
+  );
+  
+  public static final String getExtension(String type) {
+    return extensions.get(type);
+  }
+
+}

--- a/src/main/java/Request/Request.java
+++ b/src/main/java/Request/Request.java
@@ -5,7 +5,6 @@ public class Request {
   private String uri;
   private String version;
   private HashMap<String, String> headers; 
-  private HashMap<String, String> messageBody; 
   private String body; 
 
   public static class Builder {
@@ -13,13 +12,11 @@ public class Request {
     private String uri;
     private String version;
     private HashMap<String, String> headers;
-    private HashMap<String, String> messageBody;
     private String body; 
     
     public Builder() {
       this.version = "1.1";
       this.headers = new HashMap<String, String>();
-      this.messageBody = new HashMap<String, String>();
       this.body = "";
     }
     
@@ -48,16 +45,6 @@ public class Request {
       return this;
     }
 
-    public Builder addMessageBodyKeyVal(String key, String value) {
-      this.messageBody.put(key, value);
-      return this;
-    }
-
-    public Builder messageBody(HashMap<String, String> messageBody) {
-      this.messageBody = messageBody;
-      return this;
-    }
-
     public Builder body(String body) {
       this.body = body;
       return this;
@@ -73,7 +60,6 @@ public class Request {
     this.uri = builder.uri;
     this.version = builder.version;
     this.headers = builder.headers;
-    this.messageBody = builder.messageBody;
     this.body = builder.body;
   }
 
@@ -95,10 +81,6 @@ public class Request {
 
   public HashMap<String, String> getHeaders() {
     return this.headers;
-  }
-
-  public HashMap<String, String> getMessageBody() {
-    return this.messageBody;
   }
 
   public String getBody() {

--- a/src/main/java/Request/Request.java
+++ b/src/main/java/Request/Request.java
@@ -6,6 +6,7 @@ public class Request {
   private String version;
   private HashMap<String, String> headers; 
   private HashMap<String, String> messageBody; 
+  private String body; 
 
   public static class Builder {
     private String method;
@@ -13,11 +14,13 @@ public class Request {
     private String version;
     private HashMap<String, String> headers;
     private HashMap<String, String> messageBody;
+    private String body; 
     
     public Builder() {
       this.version = "1.1";
       this.headers = new HashMap<String, String>();
       this.messageBody = new HashMap<String, String>();
+      this.body = "";
     }
     
     public Builder method(String method) {
@@ -55,6 +58,11 @@ public class Request {
       return this;
     }
 
+    public Builder body(String body) {
+      this.body = body;
+      return this;
+    }
+
     public Request build() {
       return new Request(this);
     }
@@ -66,6 +74,7 @@ public class Request {
     this.version = builder.version;
     this.headers = builder.headers;
     this.messageBody = builder.messageBody;
+    this.body = builder.body;
   }
 
     public String getMethod() {
@@ -91,5 +100,9 @@ public class Request {
   public HashMap<String, String> getMessageBody() {
     return this.messageBody;
   }
-  
+
+  public String getBody() {
+    return this.body;
+  }
+
 }

--- a/src/main/java/Request/RequestParser.java
+++ b/src/main/java/Request/RequestParser.java
@@ -12,14 +12,16 @@ public class RequestParser {
   public Request generateRequest() throws BadRequestException {
     RequestLine requestLine = parseRequestLine();
     HashMap<String, String> headers = parseHeaders();
-    HashMap<String, String> messageBody = parseMessageBody();
+    String body = parseBody();
+    // HashMap<String, String> messageBody = parseMessageBody();
     
     return new Request.Builder()
                       .method(requestLine.getMethod())
                       .uri(requestLine.getURI())
                       .version(requestLine.getHTTPVersion())
                       .headers(headers)
-                      .messageBody(messageBody)
+                      .body(body)
+                      // .messageBody(messageBody)
                       .build();
   }
 
@@ -59,19 +61,28 @@ public class RequestParser {
     return updatedHeaders;
   }
 
-  private HashMap<String, String> parseMessageBody() throws BadRequestException {
+  private String parseBody() throws BadRequestException {
     try {
       String stringifiedMessageBody = stringifyMessageBody();
-      HashMap<String, String> messageBody = new HashMap<String, String>();
-      if (stringifiedMessageBody.length() > 0) {
-        putStringifiedBodyInMessageBody(stringifiedMessageBody, messageBody);
-      } 
-  
-      return messageBody;
-    } catch (ArrayIndexOutOfBoundsException | IOException e) {
+      return (stringifiedMessageBody.length() > 0) ? stringifiedMessageBody : "";
+      } catch (ArrayIndexOutOfBoundsException | IOException e) {
       throw new BadRequestException("Could not parse request message body.");
     }
   }
+  
+  // private HashMap<String, String> parseMessageBody() throws BadRequestException {
+  //   try {
+  //     String stringifiedMessageBody = stringifyMessageBody();
+  //     HashMap<String, String> messageBody = new HashMap<String, String>();
+  //     if (stringifiedMessageBody.length() > 0) {
+  //       putStringifiedBodyInMessageBody(stringifiedMessageBody, messageBody);
+  //     } 
+  
+  //     return messageBody;
+  //   } catch (ArrayIndexOutOfBoundsException | IOException e) {
+  //     throw new BadRequestException("Could not parse request message body.");
+  //   }
+  // }
 
   private String stringifyMessageBody() throws IOException {
     StringBuilder stringBuilder = new StringBuilder();
@@ -82,18 +93,18 @@ public class RequestParser {
     return stringBuilder.toString();
   }
   
-  private HashMap<String, String> putStringifiedBodyInMessageBody(String stringifiedMessageBody, HashMap<String, String> messageBody) {
-    HashMap<String, String> updatedMessageBody = messageBody;
+  // private HashMap<String, String> putStringifiedBodyInMessageBody(String stringifiedMessageBody, HashMap<String, String> messageBody) {
+  //   HashMap<String, String> updatedMessageBody = messageBody;
     
-    String[] splitMessageBody = stringifiedMessageBody.split("&");
-    for (String keyValPair : splitMessageBody) {
-      String[] splitKeyValPair = keyValPair.split("=");
-      String key = splitKeyValPair[0];
-      String val = splitKeyValPair[1];
-      updatedMessageBody.put(key, val);
-    }
+  //   String[] splitMessageBody = stringifiedMessageBody.split("&");
+  //   for (String keyValPair : splitMessageBody) {
+  //     String[] splitKeyValPair = keyValPair.split("=");
+  //     String key = splitKeyValPair[0];
+  //     String val = splitKeyValPair[1];
+  //     updatedMessageBody.put(key, val);
+  //   }
 
-    return updatedMessageBody;
-  }
+  //   return updatedMessageBody;
+  // }
 
 }

--- a/src/main/java/Request/RequestParser.java
+++ b/src/main/java/Request/RequestParser.java
@@ -13,7 +13,6 @@ public class RequestParser {
     RequestLine requestLine = parseRequestLine();
     HashMap<String, String> headers = parseHeaders();
     String body = parseBody();
-    // HashMap<String, String> messageBody = parseMessageBody();
     
     return new Request.Builder()
                       .method(requestLine.getMethod())
@@ -21,7 +20,6 @@ public class RequestParser {
                       .version(requestLine.getHTTPVersion())
                       .headers(headers)
                       .body(body)
-                      // .messageBody(messageBody)
                       .build();
   }
 
@@ -69,20 +67,6 @@ public class RequestParser {
       throw new BadRequestException("Could not parse request message body.");
     }
   }
-  
-  // private HashMap<String, String> parseMessageBody() throws BadRequestException {
-  //   try {
-  //     String stringifiedMessageBody = stringifyMessageBody();
-  //     HashMap<String, String> messageBody = new HashMap<String, String>();
-  //     if (stringifiedMessageBody.length() > 0) {
-  //       putStringifiedBodyInMessageBody(stringifiedMessageBody, messageBody);
-  //     } 
-  
-  //     return messageBody;
-  //   } catch (ArrayIndexOutOfBoundsException | IOException e) {
-  //     throw new BadRequestException("Could not parse request message body.");
-  //   }
-  // }
 
   private String stringifyMessageBody() throws IOException {
     StringBuilder stringBuilder = new StringBuilder();
@@ -93,18 +77,4 @@ public class RequestParser {
     return stringBuilder.toString();
   }
   
-  // private HashMap<String, String> putStringifiedBodyInMessageBody(String stringifiedMessageBody, HashMap<String, String> messageBody) {
-  //   HashMap<String, String> updatedMessageBody = messageBody;
-    
-  //   String[] splitMessageBody = stringifiedMessageBody.split("&");
-  //   for (String keyValPair : splitMessageBody) {
-  //     String[] splitKeyValPair = keyValPair.split("=");
-  //     String key = splitKeyValPair[0];
-  //     String val = splitKeyValPair[1];
-  //     updatedMessageBody.put(key, val);
-  //   }
-
-  //   return updatedMessageBody;
-  // }
-
 }

--- a/src/main/java/Response/HttpStatusCode.java
+++ b/src/main/java/Response/HttpStatusCode.java
@@ -8,6 +8,7 @@ public class HttpStatusCode {
   public static final int BAD_REQUEST= 400;
   public static final int NOT_FOUND = 404;
   public static final int METHOD_NOT_ALLOWED = 405;
+  public static final int UNSUPPORTED_MEDIA_TYPE = 415;
   public static final int INTERNAL_SERVER_ERROR = 500;
 
   private static final Map<Integer, String> messages = Map.ofEntries(
@@ -18,7 +19,8 @@ public class HttpStatusCode {
     Map.entry(METHOD_NOT_ALLOWED, "Method Not Allowed"),
     Map.entry(NO_CONTENT, "No Content"),
     Map.entry(NOT_FOUND, "Not Found"),
-    Map.entry(SEE_OTHER, "See Other")
+    Map.entry(SEE_OTHER, "See Other"),
+    Map.entry(UNSUPPORTED_MEDIA_TYPE, "Unsupported Media Type")
   );
 
   public static final String getReasonPhrase(int statusCode) {

--- a/src/main/java/util/Util.java
+++ b/src/main/java/util/Util.java
@@ -1,0 +1,10 @@
+import java.util.Random;
+
+public class Util {
+
+  public static String createRandomFileName(String extension) {
+    int rand = new Random().nextInt(999999999) + 100000000;
+    return Integer.toString(rand) + extension;
+  }
+
+}

--- a/src/test/java/Handler/FormHandlerTest.java
+++ b/src/test/java/Handler/FormHandlerTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Test; 
 
 public class FormHandlerTest {
+  private final static String BODY = createBody();
   private final static String FIRST_KEY = "firstKey";
   private final static String FIRST_VAL = "firstVal";
   private final static String POST_METHOD = "POST";
@@ -12,39 +13,55 @@ public class FormHandlerTest {
   private final static String SECOND_VAL = "secondVal";
   private final static String URI = "/api/form";
   
+  private static Handler formHandler;
   private static String seeOtherUri;
   private static Response response;
   
   @BeforeClass
   public static void setUp() throws NonexistentDirectoryException {
     Directory mockDirectory = new MockDirectory();
-    Handler formHandler = new FormHandler(mockDirectory); 
+    formHandler = new FormHandler(mockDirectory); 
 
-    Request request = TestUtil.buildRequestToUriWithMessageBody(POST_METHOD, URI, createMessageBody());
+    Request request = TestUtil.buildRequestToUriWithBody(POST_METHOD, URI, BODY);
     response = formHandler.generateResponse(request);
     seeOtherUri = response.getHeader(MessageHeader.LOCATION);
+  }  
+  
+  @Test 
+  public void returns400BadRequestWithMalformedBody() {
+    String body = "keyWithoutValue=";
+    Request request = TestUtil.buildRequestToUriWithBody("POST", URI, body);
+    Response response = formHandler.generateResponse(request);
+                                 
+    int expectedStatusCode = HttpStatusCode.BAD_REQUEST;
+    int actualStatusCode = response.getStatusCode();
+    assertEquals(expectedStatusCode, actualStatusCode);
+
+    String expectedReasonPhrase = HttpStatusCode.getReasonPhrase(expectedStatusCode);
+    String actualReasonPhrase = response.getReasonPhrase();
+    assertEquals(expectedReasonPhrase, actualReasonPhrase);
   }
   
   @Test
-  public void returnsStatusCode303SeeOther() {
-    int statusCode = response.getStatusCode();
-    String reasonPhrase = response.getReasonPhrase();
-    assertEquals(HttpStatusCode.SEE_OTHER, statusCode);
-    assertEquals(HttpStatusCode.getReasonPhrase(HttpStatusCode.SEE_OTHER), response.getReasonPhrase());
+  public void returns303SeeOtherAfterSuccessfulPost() {
+    int expectedStatusCode = HttpStatusCode.SEE_OTHER;
+    int actualStatusCode = response.getStatusCode();
+    assertEquals(expectedStatusCode, actualStatusCode);
+
+    String expectedReasonPhrase = HttpStatusCode.getReasonPhrase(expectedStatusCode);
+    String actualReasonPhrase = response.getReasonPhrase();
+    assertEquals(expectedReasonPhrase, actualReasonPhrase);
   }
 
   @Test
-  public void returnsLocationHeaderField() {
+  public void returnsLocationHeaderFieldAfterSuccesfulPost() {
     HashMap<String, String> headers = response.getHeaders();
     this.seeOtherUri = headers.get(MessageHeader.LOCATION);
     assertTrue(headers.containsKey(MessageHeader.LOCATION));
   }
 
-  private static HashMap<String, String> createMessageBody() {
-    HashMap<String, String> messageBody = new HashMap<String, String>();
-    messageBody.put(FIRST_KEY, FIRST_VAL);
-    messageBody.put(SECOND_KEY, SECOND_VAL);
-    return messageBody;
+  private static String createBody() {
+    return String.format("%s=%s&%s=%s", FIRST_KEY, FIRST_VAL, SECOND_KEY, SECOND_VAL);
   }
 
 }

--- a/src/test/java/Handler/PeopleHandlerTest.java
+++ b/src/test/java/Handler/PeopleHandlerTest.java
@@ -1,0 +1,87 @@
+import java.io.IOException; 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import static org.junit.Assert.assertEquals; 
+import org.junit.BeforeClass; 
+import org.junit.Test; 
+
+public class PeopleHandlerTest {
+  private final static String PEOPLE_URI = "/people";
+  private final static String SUPPORTED_MEDIA_TYPE = "application/json";
+  private final static String UNSUPPORTED_MEDIA_TYPE = "unsupported/type";
+  private final static HashMap<String, String> HEADERS_WITH_SUPPORTED_MEDIA = buildHeadersWithSupportedMediaType();
+  
+  private static Handler peopleHandler;
+
+  @BeforeClass
+  public static void setUp() throws NonexistentDirectoryException {
+    Directory mockDirectory = new MockDirectory();
+    peopleHandler = new PeopleHandler(mockDirectory);
+  }
+
+  @Test 
+  public void returns415UnsupportedMediaTypeWithIncompatibleMediaType() {
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put(MessageHeader.CONTENT_TYPE, "unsupported/type");
+    Request request = new Request.Builder()
+                                 .method("POST")
+                                 .uri(PEOPLE_URI)
+                                 .headers(headers)
+                                 .build();
+    Response response = peopleHandler.generateResponse(request);
+                                 
+    int expectedStatusCode = HttpStatusCode.UNSUPPORTED_MEDIA_TYPE;
+    int actualStatusCode = response.getStatusCode();
+    assertEquals(expectedStatusCode, actualStatusCode);
+
+    String expectedReasonPhrase = HttpStatusCode.getReasonPhrase(expectedStatusCode);
+    String actualReasonPhrase = response.getReasonPhrase();
+    assertEquals(expectedReasonPhrase, actualReasonPhrase);
+  }
+
+  @Test 
+  public void returns201CreatedWithCompatibleMediaType() {
+    Request request = new Request.Builder()
+                                 .method("POST")
+                                 .uri(PEOPLE_URI)
+                                 .headers(HEADERS_WITH_SUPPORTED_MEDIA)
+                                 .build();
+    Response response = peopleHandler.generateResponse(request);
+                                 
+    int expectedStatusCode = HttpStatusCode.CREATED;
+    int actualStatusCode = response.getStatusCode();
+    assertEquals(expectedStatusCode, actualStatusCode);
+
+    String expectedReasonPhrase = HttpStatusCode.getReasonPhrase(expectedStatusCode);
+    String actualReasonPhrase = response.getReasonPhrase();
+    assertEquals(expectedReasonPhrase, actualReasonPhrase);
+  }
+
+  @Test 
+  public void returns405MethodNotAllowedWithUnallowedMethod() {
+    String method = "NOT_ALLOWED";
+    Request request = new Request.Builder()
+                                 .method(method)
+                                 .uri(PEOPLE_URI)
+                                 .headers(HEADERS_WITH_SUPPORTED_MEDIA)
+                                 .build();
+    Response response = peopleHandler.generateResponse(request);
+                                 
+    int expectedStatusCode = HttpStatusCode.METHOD_NOT_ALLOWED;
+    int actualStatusCode = response.getStatusCode();
+    assertEquals(expectedStatusCode, actualStatusCode);
+
+    String expectedReasonPhrase = HttpStatusCode.getReasonPhrase(expectedStatusCode);
+    String actualReasonPhrase = response.getReasonPhrase();
+    assertEquals(expectedReasonPhrase, actualReasonPhrase);
+  }
+
+  private static HashMap<String, String> buildHeadersWithSupportedMediaType() {
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put(MessageHeader.CONTENT_TYPE, SUPPORTED_MEDIA_TYPE);
+    return headers;
+  }
+
+}

--- a/src/test/java/Logger/LogFormatterTest.java
+++ b/src/test/java/Logger/LogFormatterTest.java
@@ -7,8 +7,8 @@ public class LogFormatterTest {
   private final static String CONTENT_TYPE = "application/x-www-form-urlencoded";
   private final static String CONTENT_LENGTH = "13";
   private final static String MESSAGE_BODY = "hello, world!";
-  private final static String MESSAGE_BODY_KEY = "hello";
-  private final static String MESSAGE_BODY_VAL = "world";
+  // private final static String MESSAGE_BODY_KEY = "hello";
+  // private final static String MESSAGE_BODY_VAL = "world";
   private final static String METHOD = "GET";
   private final static String REASON_PHRASE = "OK";
   private final static String URI = "/uri/path";
@@ -46,7 +46,7 @@ public class LogFormatterTest {
                       .version(VERSION)
                       .setHeader(MessageHeader.CONTENT_TYPE, CONTENT_TYPE)
                       .setHeader(MessageHeader.CONTENT_LENGTH, CONTENT_LENGTH)
-                      .addMessageBodyKeyVal(MESSAGE_BODY_KEY, MESSAGE_BODY_VAL)
+                      .body(MESSAGE_BODY)
                       .build();
   }
 

--- a/src/test/java/Mock/MockDirectory.java
+++ b/src/test/java/Mock/MockDirectory.java
@@ -49,8 +49,10 @@ public class MockDirectory extends Directory {
     return this.fileTypes.get(uri);
   }
 
-  public void createFileWithContent (String uri, byte[] content) {
+  public boolean createFileWithContent (String uri, byte[] content) {
     this.files.add(uri);
+    this.fileContents.put(uri, content.toString());
+    return true;
   }
 
   public Directory createSubdirectory(String uri) throws NonexistentDirectoryException {

--- a/src/test/java/Request/RequestParserTest.java
+++ b/src/test/java/Request/RequestParserTest.java
@@ -3,7 +3,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
-import java.util.HashMap;
 import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,11 +37,10 @@ public class RequestParserTest {
     assertEquals("application/x-www-form-urlencoded", request.getHeader(MessageHeader.CONTENT_TYPE));
   }
 
-  // @Test
-  // public void parsesMessaegeBody() {
-  //   HashMap<String, String> messageBody = request.getMessageBody();
-  //   assertEquals("mundo", messageBody.get("hola"));
-  // }
+  @Test
+  public void parseBody() {
+    assertEquals(MESSAGE_BODY, request.getBody());
+  }
 
   @Test 
   public void throwsBadRequestException() throws BadRequestException {

--- a/src/test/java/Request/RequestParserTest.java
+++ b/src/test/java/Request/RequestParserTest.java
@@ -38,11 +38,11 @@ public class RequestParserTest {
     assertEquals("application/x-www-form-urlencoded", request.getHeader(MessageHeader.CONTENT_TYPE));
   }
 
-  @Test
-  public void parsesMessaegeBody() {
-    HashMap<String, String> messageBody = request.getMessageBody();
-    assertEquals("mundo", messageBody.get("hola"));
-  }
+  // @Test
+  // public void parsesMessaegeBody() {
+  //   HashMap<String, String> messageBody = request.getMessageBody();
+  //   assertEquals("mundo", messageBody.get("hola"));
+  // }
 
   @Test 
   public void throwsBadRequestException() throws BadRequestException {

--- a/src/test/java/Request/RequestTest.java
+++ b/src/test/java/Request/RequestTest.java
@@ -4,30 +4,23 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class RequestTest {
-  private final static String CONTENT_TYPE = "application/x-www-form-urlencoded";
-  private final static String CONTENT_LENGTH = "";
-  private final static String MESSAGE_BODY_KEY = "hello";
-  private final static String MESSAGE_BODY_VAL = "13";
+  private final static String BODY = "request body";
+  private final static String FIRST_HEADER_FIELD = "First-Header-Field";
+  private final static String FIRST_HEADER_VAL = "First-Header-Val";
+  private final static String CONTENT_LENGTH = "100";
+  private final static HashMap<String, String> HEADERS = setHeaders();
   private final static String METHOD = "GET";
+  private final static String SECOND_HEADER_FIELD = "Second-Header-Field";
+  private final static String SECOND_HEADER_VAL = "Second-Header-Val";
   private final static String URI = "/uri/path";
   private final static String VERSION = "1.1";
   
-  private static HashMap<String, String> headers;
-  private static HashMap<String, String> messageBody;
   private static Request request;
                   
   @BeforeClass 
   public static void setUp() {
-    headers = setHeaders();
-    messageBody = setMessageBody();
-    request = new Request.Builder()
-                         .method(METHOD)
-                         .uri(URI)
-                         .version(VERSION)
-                         .headers(headers)
-                         .messageBody(messageBody)
-                         .build();
-  }
+    request = buildRequest();
+  } 
                           
   @Test 
   public void getsMethod() {
@@ -46,34 +39,33 @@ public class RequestTest {
 
   @Test 
   public void getsHeadersHashMap() {
-    HashMap<String, String> expectedHeaders = headers;
+    HashMap<String, String> expectedHeaders = HEADERS;
     HashMap<String, String> actualHeaders = request.getHeaders();
     assertEquals(expectedHeaders, actualHeaders);
   }
 
   @Test 
-  public void setsHeadersWithAStringValue() {
-    assertEquals(CONTENT_TYPE, request.getHeader(MessageHeader.CONTENT_TYPE));
-  }
-
-  @Test 
-  public void getsMessageBodyHashMap() {
-    HashMap<String, String> expectedMessageBody = messageBody;
-    HashMap<String, String> actualMessageBody = request.getMessageBody();
-    assertEquals(expectedMessageBody, actualMessageBody);
+  public void getsMessageBody() {
+    String expectedBody = BODY;
+    String actualBody = request.getBody();
+    assertEquals(expectedBody, actualBody);
   }
 
   private static HashMap<String, String> setHeaders() {
     HashMap<String, String> headers = new HashMap<String, String>();
-    headers.put(MessageHeader.CONTENT_TYPE, CONTENT_TYPE);
-    headers.put(MessageHeader.CONTENT_LENGTH, CONTENT_LENGTH);
+    headers.put(FIRST_HEADER_FIELD, FIRST_HEADER_VAL);
+    headers.put(SECOND_HEADER_FIELD, SECOND_HEADER_VAL);
     return headers;
   }
 
-  private static HashMap<String, String> setMessageBody() {
-    HashMap<String, String> messageBody = new HashMap<String, String>();
-    messageBody.put(MESSAGE_BODY_KEY, MESSAGE_BODY_VAL);
-    return messageBody;
+  private static Request buildRequest() {
+    return new Request.Builder()
+                      .method(METHOD)
+                      .uri(URI)
+                      .version(VERSION)
+                      .headers(HEADERS)
+                      .body(BODY)
+                      .build();
   }
-  
+
 }

--- a/src/test/java/StepDefinitions/DirectoryStepDefs.java
+++ b/src/test/java/StepDefinitions/DirectoryStepDefs.java
@@ -2,20 +2,33 @@ import cucumber.api.java.en.Given;
 import cucumber.api.PendingException;
 import java.io.File;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DirectoryStepDefs {
   private final static String TEST_DIRECTORY_PATH = System.getProperty("TEST_DIRECTORY_PATH"); 
 
-  @Given("^a file with the name (.+) exists in the root directory$")
-  public void a_file_with_the_name_exists_in_the_root_directory(String fileName) throws Throwable {
-    File file = new File(TEST_DIRECTORY_PATH + "/" + fileName);
+  @Given("^a file with the name (.+) exists in (.+)$")
+  public void a_file_with_the_name_exists_in_the_root_directory(String fileName, String directoryUri) throws Throwable {
+    File file = new File(getFileUri(fileName, directoryUri));
     file.createNewFile();
   }
 
-  @Given("^a file with the name (.+) does not exist in the root directory$")
-  public void a_file_with_the_name_does_not_exist_in_the_root_directory(String fileName) throws Throwable {
-    File file = new File(TEST_DIRECTORY_PATH + "/" + fileName);
+  @Given("^a file with the name (.+) does not exist in (.+)")
+  public void a_file_with_the_name_does_not_exist_in(String fileName, String directoryUri) throws Throwable {
+    File file = new File(getFileUri(fileName, directoryUri));
+    if (file.exists()) file.delete();
     assertFalse(file.exists());
   }
-  
+
+  @Given("^a directory (.+) exists$")
+  public void a_directory_POSTed_exists(String directoryURI) throws Throwable {
+    File directory = new File(TEST_DIRECTORY_PATH + directoryURI);
+    if (!directory.isDirectory()) directory.mkdirs();
+    assertTrue(directory.exists());
+  }
+
+  private String getFileUri(String fileName, String directoryUri) {
+    return TEST_DIRECTORY_PATH + directoryUri + "/" + fileName;
+  } 
+
 }

--- a/src/test/java/StepDefinitions/HeaderStepDefs.java
+++ b/src/test/java/StepDefinitions/HeaderStepDefs.java
@@ -2,7 +2,7 @@ import cucumber.api.java.en.Then;
 import cucumber.api.PendingException;
 import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class HeaderStepDefs {
   private World world;
@@ -14,6 +14,11 @@ public class HeaderStepDefs {
   @Then("^the server should respond with the header (.+) (.+)$")
   public void the_server_should_respond_with_the_header(String field, String expectedValue) throws Throwable {
     assertEquals(expectedValue, this.world.con.getHeaderField(field));
+  }
+
+  @Then("^the response should contain the header (.+)$")
+  public void the_response_should_contain_the_header_Location(String field) throws Throwable {
+    assertFalse(this.world.con.getHeaderField(field) == null);
   }
 
 }

--- a/src/test/java/StepDefinitions/RequestStepDefs.java
+++ b/src/test/java/StepDefinitions/RequestStepDefs.java
@@ -1,6 +1,7 @@
 import cucumber.api.java.en.When;
 import cucumber.api.PendingException;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URL;
 import java.net.HttpURLConnection;
 
@@ -20,6 +21,27 @@ public class RequestStepDefs {
     URL url = new URL(urlString);
     this.world.con = (HttpURLConnection) url.openConnection();
     this.world.con.setRequestMethod(method);
+    this.world.con.setDoOutput(true);
+  }
+
+  @When("^the request contains the application/json message body$")
+  public void the_request_contains_the_application_json_message_body() throws Throwable {
+    this.world.con.setRequestProperty("Content-Type", "application/json");
+
+    String json = "{ \"sampleKey\": \"sampleValue\", \"anotherSampleKey\": \"anotherSampleValue\" }";
+    writeString(this.world.con, json);
+  }
+
+  @When("^the request contains the (.+) message body \"([^\"]*)\"$")
+  public void the_request_contains_the_text_plain_message_body(String contentType, String body) throws Throwable {
+    this.world.con.setRequestProperty("Content-Type", contentType);
+    writeString(this.world.con, body);
+  }
+
+  private void writeString(HttpURLConnection con, String str) throws IOException {
+    OutputStream out = con.getOutputStream();
+    out.write(str.getBytes("UTF-8"));
+    out.close();
   }
   
 }

--- a/src/test/java/util/TestUtil.java
+++ b/src/test/java/util/TestUtil.java
@@ -12,13 +12,13 @@ public class TestUtil {
                       .version("1.1") 
                       .build(); 
   }
-
-  public static Request buildRequestToUriWithMessageBody(String method, String uri, HashMap<String, String> messageBody) {
+  
+  public static Request buildRequestToUriWithBody(String method, String uri, String body) {
     return new Request.Builder() 
                       .method(method) 
                       .uri(uri) 
                       .version("1.1") 
-                      .messageBody(messageBody)
+                      .body(body)
                       .build(); 
   }
   

--- a/src/test/resources/features/createResource.feature
+++ b/src/test/resources/features/createResource.feature
@@ -1,0 +1,22 @@
+Feature: Create a resource
+
+Background: 
+  Given a directory /people exists 
+
+Scenario: POST request with JSON
+  When a client makes a POST request to /api/people
+  And the request contains the application/json message body
+  Then the server should respond with status code 201 Created
+  And the response should contain the header Location
+
+Scenario: POST request with plain text  
+  When a client makes a POST request to /api/people
+  And the request contains the text/plain message body "plain text body"
+  Then the server should respond with status code 201 Created
+  And the response should contain the header Location
+  
+Scenario: POST request with unsupported content type
+  When a client makes a POST request to /api/people
+  And the request contains the unsupported/type message body "this type is not supported"
+  Then the server should respond with status code 415 Unsupported Media Type
+  

--- a/src/test/resources/features/delete.feature
+++ b/src/test/resources/features/delete.feature
@@ -1,7 +1,7 @@
 Feature: Delete a resource
 
 Scenario: DELETE request to an existing resource 
-  Given a file with the name will-be-deleted.txt exists in the root directory
+  Given a file with the name will-be-deleted.txt exists in /
   When a client makes a DELETE request to /will-be-deleted.txt
   Then the server should respond with status code 204 No Content 
   


### PR DESCRIPTION
## Main 
This class adds the `api/people` route, which sends `Request`s with that URI to `PeopleHandler`;

## PeopleHandler
The `PeopleHandler` class takes an incoming `Request` and creates a resource based on the body if and only if that file type is supported by the Handler. Currently, `PeopleHandler` accepts JSON and plain text bodies. The class can be configured to accept additional content types by adding to the `final static String[] SUPPORTED_MEDIA_TYPES`. Requests containing unsupported types return `415 Unsupported Media Type`.

## MimeType
Much like the `HttpStatusCode` class exposes static status codes and messages, the `MimeType` exposes static `Content-Type`s and file extensions. This class can be used by any `Handler` that creates file types and/or constructs response message bodies based on the incoming `Content-Type`. 

## RequestParser & Request
In order to permit different `Handler`s to read and manipulate `Request` bodies how they see fit, I've removed the business logic of parsing and formatting the incoming `Request` body into key value pairs. Instead, `Request` now stores the body as a String. 

## Util
I've created this class to consolidate repeated methods across some of the classes. Currently, the class only holds the static method `#createRandomFileName(String extension)`, which was previously duplicated in `FormHandler` and `PeopleHandler`. 


