### PR TITLE
Handle PATCH Requests to JSON Resources With JSON Patch Format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ repositories {
 }
 
 dependencies {
+    compile group: 'org.json', name: 'json', version: '20180813'
+
     testCompile group: 'info.cukes', name: 'cucumber-picocontainer', version: '1.2.5'
     testCompile 'info.cukes:cucumber-java:1.2.4'
     testCompile 'info.cukes:cucumber-junit:1.2.4'

--- a/src/main/java/Directory.java
+++ b/src/main/java/Directory.java
@@ -1,5 +1,6 @@
 import java.io.BufferedReader; 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.FileOutputStream;
 import java.io.FileReader; 
 import java.io.IOException;

--- a/src/main/java/Directory.java
+++ b/src/main/java/Directory.java
@@ -15,6 +15,7 @@ public class Directory {
     Map.entry("html", "text/html"),
     Map.entry("jpg", "image/jpeg"),
     Map.entry("jpeg", "image/jpeg"),
+    Map.entry("json", "application/json"),
     Map.entry("png", "image/png"),
     Map.entry("txt", "text/plain")
   );

--- a/src/main/java/Directory.java
+++ b/src/main/java/Directory.java
@@ -97,6 +97,20 @@ public class Directory {
     }
   }
 
+  public boolean overwriteFileWithStringContent(String uri, String content) {
+    try {
+      File file = new File(this.directoryPath + uri);
+      boolean shouldAppend = false;
+      FileWriter writer = new FileWriter(file, shouldAppend);
+      writer.write(content); 
+      return true;
+    } catch(IOException e) {
+      System.err.println("Could not overwrite String content to file.");
+      System.err.println(e);
+      return false;
+    }
+  }
+
   public Directory createSubdirectory(String uri) throws NonexistentDirectoryException {
     return new Directory(this.directoryPath + uri);
   }

--- a/src/main/java/Exception/UnprocessableEntityException.java
+++ b/src/main/java/Exception/UnprocessableEntityException.java
@@ -1,0 +1,6 @@
+public class UnprocessableEntityException extends Exception {
+
+  public UnprocessableEntityException (String message) {
+    super(message);
+  }
+}

--- a/src/main/java/Handler/FileHandler.java
+++ b/src/main/java/Handler/FileHandler.java
@@ -1,6 +1,7 @@
-import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.List;
 
- public class FileHandler implements Handler {   
+ public class FileHandler implements Handler {         
   private Directory directory;
   
   public FileHandler(Directory directory) {

--- a/src/main/java/Handler/PatchHandler.java
+++ b/src/main/java/Handler/PatchHandler.java
@@ -10,7 +10,7 @@ public class PatchHandler implements Handler {
   }  
 
   public Response generateResponse(Request request) {
-    try {
+    try {      
       String requestContentType = request.getHeader(MessageHeader.CONTENT_TYPE);   
       if (!this.directory.existsInStore(request.getURI())) {
         return new Response.Builder(HttpStatusCode.NOT_FOUND)
@@ -22,7 +22,7 @@ public class PatchHandler implements Handler {
       }
   
       String updatedResourceContent = getUpdatedResourceContent(request);
-      this.directory.overwriteFileWithContent(request.getURI(), updatedResourceContent.getBytes());
+      this.directory.overwriteFileWithStringContent(request.getURI(), updatedResourceContent);
       return buildOkResponse(request);
     } catch (BadRequestException e) {
       return new Response.Builder(HttpStatusCode.BAD_REQUEST)

--- a/src/main/java/Handler/PatchHandler.java
+++ b/src/main/java/Handler/PatchHandler.java
@@ -17,12 +17,12 @@ public class PatchHandler implements Handler {
                            .build();
       } else if (!requestContentType.equals(MimeType.JSON_PATCH)) {
         return new Response.Builder(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE)
-                           .setHeader(MessageHeader.ACCEPT_PATCH, MimeType.JSON_PATCH)
-                           .build();
+                      .setHeader(MessageHeader.ACCEPT_PATCH, MimeType.JSON_PATCH)
+                      .build();
       }
   
       String updatedResourceContent = getUpdatedResourceContent(request);
-      this.directory.overwriteFileWithStringContent(request.getURI(), updatedResourceContent);
+      this.directory.overwriteFileWithContent(request.getURI(), updatedResourceContent.getBytes());
       return buildOkResponse(request);
     } catch (BadRequestException e) {
       return new Response.Builder(HttpStatusCode.BAD_REQUEST)

--- a/src/main/java/Handler/PatchHandler.java
+++ b/src/main/java/Handler/PatchHandler.java
@@ -1,0 +1,57 @@
+import java.util.ArrayList;
+
+public class PatchHandler implements Handler {
+  private Directory directory;
+  private JsonPatchParser jsonPatchParser;
+  
+  public PatchHandler(Directory directory, JsonPatchParser jsonPatchParser) {
+    this.directory = directory;
+    this.jsonPatchParser = jsonPatchParser;
+  }  
+
+  public Response generateResponse(Request request) {
+    try {
+      String requestContentType = request.getHeader(MessageHeader.CONTENT_TYPE);   
+      if (!this.directory.existsInStore(request.getURI())) {
+        return new Response.Builder(HttpStatusCode.NOT_FOUND)
+                           .build();
+      } else if (!requestContentType.equals(MimeType.JSON_PATCH)) {
+        return new Response.Builder(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE)
+                           .setHeader(MessageHeader.ACCEPT_PATCH, MimeType.JSON_PATCH)
+                           .build();
+      }
+  
+      String updatedResourceContent = getUpdatedResourceContent(request);
+      this.directory.overwriteFileWithContent(request.getURI(), updatedResourceContent.getBytes());
+      return buildOkResponse(request);
+    } catch (BadRequestException e) {
+      return new Response.Builder(HttpStatusCode.BAD_REQUEST)
+                         .build();
+    } catch (UnprocessableEntityException e) {
+      return new Response.Builder(HttpStatusCode.UNPROCESSABLE_ENTITY)
+                         .build();
+    }
+    
+  }
+
+  private String getUpdatedResourceContent(Request request) throws BadRequestException, UnprocessableEntityException {
+    String uri = request.getURI();
+    String updatedResourceContent = new String(this.directory.readFile(uri));
+    ArrayList<JsonPatchOperation> patches = this.jsonPatchParser.getOperations(request.getBody());
+    for (JsonPatchOperation patch : patches) {
+      updatedResourceContent = patch.applyOperation(updatedResourceContent);
+    }
+
+    return updatedResourceContent;
+  }
+
+  private Response buildOkResponse(Request request) {
+    String uri = request.getURI();
+    String fileContent = new String(this.directory.readFile(uri));
+    return new Response.Builder(HttpStatusCode.OK)
+                       .messageBody(fileContent)
+                       .setHeader(MessageHeader.CONTENT_TYPE, MimeType.JSON)
+                       .build();
+  }
+
+}

--- a/src/main/java/JsonPatch/JsonPatchAdd.java
+++ b/src/main/java/JsonPatch/JsonPatchAdd.java
@@ -1,0 +1,20 @@
+import java.util.Arrays;
+import org.json.JSONObject;
+
+public class JsonPatchAdd extends JsonPatchOperation {
+  private String value;
+  
+  public JsonPatchAdd(String op, String path, String value) {
+    super(op, path);
+    this.value = value;
+  }
+
+  @Override 
+  public String applyOperation(String original) throws BadRequestException, UnprocessableEntityException {
+    JSONObject originalAsJson = new JSONObject(original);
+    String[] keys = extractKeys(this.path);
+    originalAsJson = addValue(this.value, originalAsJson, keys);
+    return originalAsJson.toString();
+  }
+
+}

--- a/src/main/java/JsonPatch/JsonPatchCopy.java
+++ b/src/main/java/JsonPatch/JsonPatchCopy.java
@@ -1,0 +1,27 @@
+import java.util.Arrays;
+import org.json.JSONObject;
+
+public class JsonPatchCopy extends JsonPatchOperation {
+  private String from;
+
+  public JsonPatchCopy(String op, String from, String path) {
+    super(op, path);
+    this.from = from;    
+  }
+
+  @Override 
+  public String applyOperation(String original) throws BadRequestException, UnprocessableEntityException {
+    JSONObject originalAsJson = new JSONObject(original);
+    String[] fromKeys = extractKeys(this.from);
+    String[] pathKeys = extractKeys(this.path);
+    originalAsJson = copyValue(originalAsJson, fromKeys, pathKeys);
+    return originalAsJson.toString();
+  }
+  
+  private JSONObject copyValue(JSONObject jsonObject, String[] fromKeys, String[] pathKeys) throws UnprocessableEntityException {
+    String toBeRemoved = getValueFromJsonObjectGivenKeys(jsonObject, fromKeys);
+    jsonObject = addValue(toBeRemoved, jsonObject, pathKeys);
+    return jsonObject;
+  }
+  
+}

--- a/src/main/java/JsonPatch/JsonPatchMove.java
+++ b/src/main/java/JsonPatch/JsonPatchMove.java
@@ -1,0 +1,28 @@
+import java.util.Arrays;
+import org.json.JSONObject;
+
+public class JsonPatchMove extends JsonPatchOperation {
+  String from;
+
+  public JsonPatchMove(String op, String from, String path) {
+    super(op, path);
+    this.from = from;
+  }
+
+  @Override 
+  public String applyOperation(String original) throws BadRequestException, UnprocessableEntityException {
+    JSONObject originalAsJson = new JSONObject(original);
+    String[] fromKeys = extractKeys(this.from);
+    String[] pathKeys = extractKeys(this.path);
+    originalAsJson = moveValue(originalAsJson, fromKeys, pathKeys);
+    return originalAsJson.toString();
+  }
+  
+  private JSONObject moveValue(JSONObject jsonObject, String[] fromKeys, String[] pathKeys) throws UnprocessableEntityException {
+    String toBeRemoved = getValueFromJsonObjectGivenKeys(jsonObject, fromKeys);
+    jsonObject = removeValue(jsonObject, fromKeys);
+    jsonObject = addValue(toBeRemoved, jsonObject, pathKeys);
+    return jsonObject;
+  }
+  
+}

--- a/src/main/java/JsonPatch/JsonPatchOperation.java
+++ b/src/main/java/JsonPatch/JsonPatchOperation.java
@@ -1,0 +1,69 @@
+import org.json.JSONObject;
+import java.util.Arrays;
+
+
+public abstract class JsonPatchOperation {
+  protected String op; 
+  protected String path;
+
+  public JsonPatchOperation(String op, String path) {
+    this.op = op;
+    this.path = path;
+  }
+
+  abstract String applyOperation(String original) throws BadRequestException, UnprocessableEntityException; 
+
+  protected String[] extractKeys(String path) throws BadRequestException {
+    String leadingSlash = "/";
+    if (!path.startsWith(leadingSlash)) throw new BadRequestException("Path must begin with a leading '/'");
+  
+    return path.substring(1).split(leadingSlash);
+  }
+
+  protected JSONObject addValue(String value, JSONObject jsonObject, String[] keys) throws UnprocessableEntityException {
+    String currentKey = keys[0];
+    
+    if (keys.length == 1) {
+      return jsonObject.put(currentKey, value);
+    } else if (!jsonObject.has(currentKey)) {
+      throw new UnprocessableEntityException(currentKey + "is not a valid key.");
+    }
+
+    JSONObject nestedJsonObjectVal = jsonObject.getJSONObject(currentKey);
+    String[] remainingKeys = Arrays.copyOfRange(keys, 1, keys.length);
+    JSONObject updatedNestedValue = addValue(value, nestedJsonObjectVal, remainingKeys);
+    return jsonObject.put(currentKey, updatedNestedValue);
+  }
+
+  protected JSONObject removeValue(JSONObject jsonObject, String[] keys) throws UnprocessableEntityException {
+    String currentKey = keys[0];
+    
+    if (keys.length == 1 && jsonObject.has(currentKey)) {
+      jsonObject.remove(currentKey);
+      return jsonObject;
+    } else if (!jsonObject.has(currentKey)) {
+      throw new UnprocessableEntityException(currentKey + "is not a valid key.");
+    }
+
+    JSONObject nestedJsonObjectVal = jsonObject.getJSONObject(currentKey);
+    String[] remainingKeys = Arrays.copyOfRange(keys, 1, keys.length);
+    JSONObject updatedNestedValue = removeValue(nestedJsonObjectVal, remainingKeys);
+    return jsonObject.put(currentKey, updatedNestedValue);
+  }
+
+
+  protected String getValueFromJsonObjectGivenKeys(JSONObject jsonObject, String[] keys) throws UnprocessableEntityException {
+    String currentKey = keys[0];
+
+    if (keys.length == 1 && jsonObject.has(currentKey)) {
+      return jsonObject.getString(currentKey);
+    } else if (!jsonObject.has(currentKey)) {
+      throw new UnprocessableEntityException(currentKey + "is not a valid key.");
+    }
+
+    JSONObject nestedJsonObjectVal = jsonObject.getJSONObject(currentKey);
+    String[] remainingKeys = Arrays.copyOfRange(keys, 1, keys.length);
+    return getValueFromJsonObjectGivenKeys(nestedJsonObjectVal, remainingKeys);
+  }
+
+}

--- a/src/main/java/JsonPatch/JsonPatchParser.java
+++ b/src/main/java/JsonPatch/JsonPatchParser.java
@@ -1,0 +1,82 @@
+import java.util.ArrayList;
+import java.util.Iterator;
+import org.json.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+public class JsonPatchParser {
+
+  public ArrayList<JsonPatchOperation> getOperations(String body) throws BadRequestException {    
+    try {
+      ArrayList<JsonPatchOperation> operations = new ArrayList<JsonPatchOperation>();
+      Iterator iterator  = new JSONArray(body).iterator();
+      while (iterator.hasNext()) {
+        JSONObject jsonPatchObject = (JSONObject)iterator.next();
+        JsonPatchOperation operation = createPatchFromJsonObject(jsonPatchObject);
+        operations.add(operation);
+      }
+      return operations;
+    } catch (Exception e) {
+      System.out.println(e);
+      throw new BadRequestException("Could not parse application/json-patch+json");
+    }
+  }
+
+  private JsonPatchOperation createPatchFromJsonObject(JSONObject jsonObject) throws BadRequestException {
+    try {
+      switch (jsonObject.getString("op")) { 
+        case "add":  
+          return createJsonPatchAdd(jsonObject); 
+        case "remove":  
+          return createJsonPatchRemove(jsonObject); 
+        case "replace":  
+          return createJsonPatchReplace(jsonObject); 
+        case "move":  
+          return createJsonPatchMove(jsonObject); 
+        case "copy":  
+          return createJsonPatchCopy(jsonObject); 
+        default: 
+          throw new BadRequestException(jsonObject.getString("op") + " is not a valid JSON PATCH operation.");
+
+      }
+    } catch (JSONException e) {
+      System.out.println(e);
+      throw new BadRequestException("Couldn't parse JSON Patch operation");
+    }
+  }
+
+  private JsonPatchOperation createJsonPatchAdd(JSONObject jsonObject) {
+    String op = jsonObject.getString("op");
+    String path = jsonObject.getString("path");
+    String value = jsonObject.getString("value");
+    return new JsonPatchAdd(op, path, value);
+  }
+
+  private JsonPatchOperation createJsonPatchRemove(JSONObject jsonObject) {
+    String op = jsonObject.getString("op");
+    String path = jsonObject.getString("path");
+    return new JsonPatchRemove(op, path);
+  }
+
+  private JsonPatchOperation createJsonPatchReplace(JSONObject jsonObject) {
+    String op = jsonObject.getString("op");
+    String path = jsonObject.getString("path");
+    String value = jsonObject.getString("value");
+    return new JsonPatchReplace(op, path, value);
+  }
+  
+  private JsonPatchOperation createJsonPatchMove(JSONObject jsonObject) {
+    String op = jsonObject.getString("op");
+    String from = jsonObject.getString("from");
+    String path = jsonObject.getString("path");
+    return new JsonPatchMove(op, from, path);
+  }
+
+  private JsonPatchOperation createJsonPatchCopy(JSONObject jsonObject) {
+    String op = jsonObject.getString("op");
+    String from = jsonObject.getString("from");
+    String path = jsonObject.getString("path");
+    return new JsonPatchCopy(op, from, path);
+  }
+
+}

--- a/src/main/java/JsonPatch/JsonPatchParser.java
+++ b/src/main/java/JsonPatch/JsonPatchParser.java
@@ -37,7 +37,6 @@ public class JsonPatchParser {
           return createJsonPatchCopy(jsonObject); 
         default: 
           throw new BadRequestException(jsonObject.getString("op") + " is not a valid JSON PATCH operation.");
-
       }
     } catch (JSONException e) {
       System.out.println(e);

--- a/src/main/java/JsonPatch/JsonPatchRemove.java
+++ b/src/main/java/JsonPatch/JsonPatchRemove.java
@@ -1,0 +1,18 @@
+import java.util.Arrays;
+import org.json.JSONObject;
+
+public class JsonPatchRemove extends JsonPatchOperation {
+
+  public JsonPatchRemove(String op, String path) {
+    super(op, path);
+  }
+  
+  @Override 
+  public String applyOperation(String original) throws BadRequestException, UnprocessableEntityException {
+    JSONObject originalAsJson = new JSONObject(original);
+    String[] keys = extractKeys(this.path);
+    originalAsJson = removeValue(originalAsJson, keys);
+    return originalAsJson.toString();
+  }
+
+}

--- a/src/main/java/JsonPatch/JsonPatchReplace.java
+++ b/src/main/java/JsonPatch/JsonPatchReplace.java
@@ -1,0 +1,39 @@
+import java.util.Arrays;
+import org.json.JSONObject;
+
+public class JsonPatchReplace extends JsonPatchOperation {
+  private String value;
+  
+  public JsonPatchReplace(String op, String path, String value) {
+    super(op, path);
+    this.value = value;
+  }
+
+  @Override 
+  public String applyOperation(String original) throws BadRequestException, UnprocessableEntityException {
+    JSONObject originalAsJson = new JSONObject(original);
+    String[] keys = extractKeys(this.path);
+    originalAsJson = replaceValue(originalAsJson, keys);
+    return originalAsJson.toString();
+  }
+
+  private JSONObject replaceValue(JSONObject jsonObject, String[] keys) throws UnprocessableEntityException {
+    String currentKey = keys[0];
+    
+    if (keys.length == 1 && jsonObject.has(currentKey)) {
+      return jsonObject.put(currentKey, this.value);
+    } else if (!jsonObject.has(currentKey)) {
+      throw new UnprocessableEntityException(currentKey + "is not a valid key.");
+    }
+
+    return jsonObject.put(currentKey, getUpdatedNestedValue(jsonObject, keys));
+  }
+
+  private JSONObject getUpdatedNestedValue(JSONObject jsonObject, String[] keys) throws UnprocessableEntityException {
+    String currentKey = keys[0];
+    JSONObject nestedJsonObjectVal = jsonObject.getJSONObject(currentKey);
+    String[] remainingKeys = Arrays.copyOfRange(keys, 1, keys.length);
+    return replaceValue(nestedJsonObjectVal, remainingKeys);
+  }
+
+}

--- a/src/main/java/MessageHeader.java
+++ b/src/main/java/MessageHeader.java
@@ -1,6 +1,7 @@
 import java.io.UnsupportedEncodingException;
 
 public class MessageHeader {
+  public final static String ACCEPT_PATCH = "Accept-Patch";
   public final static String CONTENT_LENGTH = "Content-Length";
   public final static String CONTENT_TYPE = "Content-Type";
   public final static String LOCATION = "Location";

--- a/src/main/java/MessageHeader.java
+++ b/src/main/java/MessageHeader.java
@@ -5,6 +5,7 @@ public class MessageHeader {
   public final static String CONTENT_LENGTH = "Content-Length";
   public final static String CONTENT_TYPE = "Content-Type";
   public final static String LOCATION = "Location";
+  public final static String METHOD_OVERRIDE = "X-HTTP-Method-Override";
   
   public static int determineContentLength(String messageBody) {
     int length = 0;

--- a/src/main/java/MimeType.java
+++ b/src/main/java/MimeType.java
@@ -2,6 +2,7 @@ import java.util.Map;
 
 public class MimeType {
   public final static String JSON = "application/json";
+  public final static String JSON_PATCH = "application/json-patch+json";
   public final static String PLAIN_TEXT = "text/plain";
 
   private static final Map<String, String> extensions = Map.ofEntries(

--- a/src/main/java/Request/RequestParser.java
+++ b/src/main/java/Request/RequestParser.java
@@ -3,6 +3,8 @@ import java.io.IOException;
 import java.util.HashMap;
 
 public class RequestParser {
+  private final static String METHOD_OVERRIDE_HEADER = "X-HTTP-Method-Override";
+  
   BufferedReader reader; 
 
   public RequestParser(BufferedReader reader) {
@@ -12,6 +14,7 @@ public class RequestParser {
   public Request generateRequest() throws BadRequestException {
     RequestLineParser requestLineParser = parseRequestLine();
     HashMap<String, String> headers = parseHeaders();
+    String method = extractMethod(requestLineParser.getMethod(), headers);
     String body = parseBody();
     
     return new Request.Builder()
@@ -48,6 +51,15 @@ public class RequestParser {
     } catch (ArrayIndexOutOfBoundsException | IOException e) {
       throw new BadRequestException("Could not parse request headers.");
     }
+  }
+
+  private String extractMethod(String givenMethod, HashMap<String, String> headers) {
+    String method = givenMethod;
+    if (headers.containsKey(METHOD_OVERRIDE_HEADER)) {
+      method = headers.get(METHOD_OVERRIDE_HEADER);
+    }
+
+    return method;
   }
 
   private HashMap<String, String> putLineInHeaders(String headersLine, HashMap<String, String> headers) {

--- a/src/main/java/Request/RequestParser.java
+++ b/src/main/java/Request/RequestParser.java
@@ -2,9 +2,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.HashMap;
 
-public class RequestParser {
-  private final static String METHOD_OVERRIDE_HEADER = "X-HTTP-Method-Override";
-  
+public class RequestParser {  
   BufferedReader reader; 
 
   public RequestParser(BufferedReader reader) {
@@ -18,7 +16,7 @@ public class RequestParser {
     String body = parseBody();
     
     return new Request.Builder()
-                      .method(requestLineParser.getMethod())
+                      .method(method)
                       .uri(requestLineParser.getURI())
                       .query(requestLineParser.getQuery())
                       .version(requestLineParser.getHTTPVersion())
@@ -55,8 +53,8 @@ public class RequestParser {
 
   private String extractMethod(String givenMethod, HashMap<String, String> headers) {
     String method = givenMethod;
-    if (headers.containsKey(METHOD_OVERRIDE_HEADER)) {
-      method = headers.get(METHOD_OVERRIDE_HEADER);
+    if (headers.containsKey(MessageHeader.METHOD_OVERRIDE)) {
+      method = headers.get(MessageHeader.METHOD_OVERRIDE);
     }
 
     return method;

--- a/src/main/java/Response/HttpStatusCode.java
+++ b/src/main/java/Response/HttpStatusCode.java
@@ -9,6 +9,7 @@ public class HttpStatusCode {
   public static final int NOT_FOUND = 404;
   public static final int METHOD_NOT_ALLOWED = 405;
   public static final int UNSUPPORTED_MEDIA_TYPE = 415;
+  public static final int UNPROCESSABLE_ENTITY = 422;
   public static final int INTERNAL_SERVER_ERROR = 500;
 
   private static final Map<Integer, String> messages = Map.ofEntries(
@@ -20,6 +21,7 @@ public class HttpStatusCode {
     Map.entry(NO_CONTENT, "No Content"),
     Map.entry(NOT_FOUND, "Not Found"),
     Map.entry(SEE_OTHER, "See Other"),
+    Map.entry(UNPROCESSABLE_ENTITY, "Unprocessable Entity"),
     Map.entry(UNSUPPORTED_MEDIA_TYPE, "Unsupported Media Type")
   );
 

--- a/src/main/java/Router.java
+++ b/src/main/java/Router.java
@@ -13,6 +13,7 @@ public class Router {
 
   public Response getResponse(Request request) {
     Handler handler = getHandler(request.getURI());
+    if (request.getMethod().equals("PATCH")) handler = new PatchHandler(this.directory, new JsonPatchParser());
     return handler.generateResponse(request);
   }
   

--- a/src/test/java/Handler/FileHandlerTest.java
+++ b/src/test/java/Handler/FileHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.BeforeClass;
 import org.junit.Test; 
  
 public class FileHandlerTest { 
+  private final static String JSON_PATCH_TYPE = "application/json/json-patch+json";
   private final static String TEXT_FILE_CONTENT = "This is a sample text file.";
   private final static String TEXT_FILE_URI = "/text-file.txt";
   private final static String TO_BE_DELETED_URI = "/to-be-deleted.txt";
@@ -92,7 +93,7 @@ public class FileHandlerTest {
     List<String> subdirectories = setUpMockSubdirectories();
     List<String> files = setUpMockFiles();   
     HashMap<String, String> fileContents = setUpMockFileContents();
-    Map<String, String> fileTypes = setUpMockFileContents();
+    Map<String, String> fileTypes = setUpMockFileTypes();
     return new MockDirectory(subdirectories, files, fileContents, fileTypes);
   }
 
@@ -116,7 +117,7 @@ public class FileHandlerTest {
 
   private static Map<String, String> setUpMockFileTypes() {
     return Map.ofEntries(
-      Map.entry(TEXT_FILE_URI, TEXT_FILE_CONTENT)
+      Map.entry(TEXT_FILE_URI, MimeType.PLAIN_TEXT)
     );
   }
 

--- a/src/test/java/Handler/NotFoundHandlerTest.java
+++ b/src/test/java/Handler/NotFoundHandlerTest.java
@@ -33,6 +33,20 @@ public class NotFoundHandlerTest {
   }
 
   @Test 
+  public void returns404NotFoundForPatchRequests() {
+    Request request = TestUtil.buildRequestToUri("PATCH", NONEXISTENT_URI);
+    Response response = notFoundHandler.generateResponse(request);
+
+    int expectedStatusCode = HttpStatusCode.NOT_FOUND;
+    int actualStatusCode = response.getStatusCode();
+    assertEquals(expectedStatusCode, actualStatusCode);
+
+    String expectedReasonPhrase = HttpStatusCode.getReasonPhrase(expectedStatusCode);
+    String actualReasonPhrase = response.getReasonPhrase();
+    assertEquals(expectedReasonPhrase, actualReasonPhrase);
+  }
+
+  @Test 
   public void returns201CreatedForPutRequestToResourceThatDoesNotExist() {
     String body = "body";
     Request request = TestUtil.buildRequestToUriWithBody("PUT", NONEXISTENT_URI, body);

--- a/src/test/java/Handler/PatchHandlerTest.java
+++ b/src/test/java/Handler/PatchHandlerTest.java
@@ -62,16 +62,6 @@ public class PatchHandlerTest {
     String actualReasonPhrase = response.getReasonPhrase();
     assertEquals(expectedReasonPhrase, actualReasonPhrase);
   }
-
-  @Test 
-  public void returnsUpdatedResourceContentAfterSuccesfulPatch() {
-    Request request = buildPatchRequestToJsonFileWithJsonPatchContent();
-    Response response = patchHandler.generateResponse(request);
-
-    String expectedResponse = "UPDATE BY OPERATION";
-    String actualResponse = new String(response.getMessageBody());
-    assertEquals(expectedResponse, actualResponse);
-  }
   
   private static MockDirectory setUpMockDirectory() throws NonexistentDirectoryException {
     List<String> files = setUpMockFiles();   

--- a/src/test/java/Handler/PatchHandlerTest.java
+++ b/src/test/java/Handler/PatchHandlerTest.java
@@ -1,0 +1,142 @@
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import static org.junit.Assert.assertEquals;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class PatchHandlerTest {
+  private final static String JSON_PATCH_TYPE = "application/json-patch+json";
+  private final static String JSON_FILE_URI = "/to-be-patched.json";
+  private final static String JSON_FILE_ORIGINAL_CONTENT = "ORIGINAL JSON FILE CONTENT";
+  
+  private static Handler patchHandler;
+
+  @BeforeClass
+  public static void setUpOnce() throws IOException, NonexistentDirectoryException {
+    MockDirectory mockDirectory = setUpMockDirectory();
+    JsonPatchParser mockJsonPatchParser = setUpMockJsonPatchParser();
+    patchHandler = new PatchHandler(mockDirectory, mockJsonPatchParser); 
+  }
+
+  @Test 
+  public void returns404NotFoundForPatchRequestToNonexistentResource() {
+    Request request = buildPatchRequestToNonexistentJsonFile();
+    Response response = patchHandler.generateResponse(request);
+
+    int expectedStatusCode = HttpStatusCode.NOT_FOUND;
+    int actualStatusCode = response.getStatusCode();
+    assertEquals(expectedStatusCode, actualStatusCode);
+
+    String expectedReasonPhrase = HttpStatusCode.getReasonPhrase(expectedStatusCode);
+    String actualReasonPhrase = response.getReasonPhrase();
+    assertEquals(expectedReasonPhrase, actualReasonPhrase);
+  }
+
+  @Test 
+  public void returns415UnsupportedMediaTypeForPatchRequestToJsonGivenANonJsonBody() {
+    Request request = buildPatchRequestToJsonFileWithPlainTextContent();
+    Response response = patchHandler.generateResponse(request);
+
+    int expectedStatusCode = HttpStatusCode.UNSUPPORTED_MEDIA_TYPE;
+    int actualStatusCode = response.getStatusCode();
+    assertEquals(expectedStatusCode, actualStatusCode);
+
+    String expectedReasonPhrase = HttpStatusCode.getReasonPhrase(expectedStatusCode);
+    String actualReasonPhrase = response.getReasonPhrase();
+    assertEquals(expectedReasonPhrase, actualReasonPhrase);
+  }
+
+  @Test 
+  public void returns200OkAfterSuccessfulPatch() {
+    Request request = buildPatchRequestToJsonFileWithJsonPatchContent();
+    Response response = patchHandler.generateResponse(request);
+
+    int expectedStatusCode = HttpStatusCode.OK;
+    int actualStatusCode = response.getStatusCode();
+    assertEquals(expectedStatusCode, actualStatusCode);
+
+    String expectedReasonPhrase = HttpStatusCode.getReasonPhrase(expectedStatusCode);
+    String actualReasonPhrase = response.getReasonPhrase();
+    assertEquals(expectedReasonPhrase, actualReasonPhrase);
+  }
+
+  @Test 
+  public void returnsUpdatedResourceContentAfterSuccesfulPatch() {
+    Request request = buildPatchRequestToJsonFileWithJsonPatchContent();
+    Response response = patchHandler.generateResponse(request);
+
+    String expectedResponse = "UPDATE BY OPERATION";
+    String actualResponse = new String(response.getMessageBody());
+    assertEquals(expectedResponse, actualResponse);
+  }
+  
+  private static MockDirectory setUpMockDirectory() throws NonexistentDirectoryException {
+    List<String> files = setUpMockFiles();   
+    HashMap<String, String> fileContents = setUpMockFileContents();
+    Map<String, String> fileTypes = setUpMockFileTypes();
+    return new MockDirectory(files, fileContents, fileTypes);
+  }
+
+  private static List<String> setUpMockFiles() {
+    ArrayList<String> files = new ArrayList<String>();
+    files.add(JSON_FILE_URI);
+    return files;
+  }
+
+  private static HashMap<String, String> setUpMockFileContents() {
+    HashMap<String, String> fileContents = new HashMap<String, String>();
+    fileContents.put(JSON_FILE_URI, JSON_FILE_ORIGINAL_CONTENT);
+    return fileContents;
+  }
+
+  private static Map<String, String> setUpMockFileTypes() {
+    return Map.ofEntries(
+      Map.entry(JSON_FILE_URI, "application/json")
+    );
+  }
+
+  private static JsonPatchParser setUpMockJsonPatchParser() {
+    ArrayList<JsonPatchOperation> mockOperations = new ArrayList<JsonPatchOperation>();
+    mockOperations.add(new MockJsonPatchOperation("UPDATE BY OPERATION"));
+    return new MockJsonPatchParser(mockOperations);
+  }
+
+  private Request buildPatchRequestToNonexistentJsonFile() {
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put(MessageHeader.CONTENT_TYPE, JSON_PATCH_TYPE);
+    String jsonPatchBody = "JSON PATCH BODY";
+    return new Request.Builder() 
+                      .method("PATCH") 
+                      .uri("does-not-exist.json") 
+                      .headers(headers)
+                      .body(jsonPatchBody)
+                      .build(); 
+  }
+
+  private Request buildPatchRequestToJsonFileWithPlainTextContent() {
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put(MessageHeader.CONTENT_TYPE, "text/plain");
+    String plainTextBody = "plain text body";
+    return new Request.Builder() 
+                      .method("PATCH") 
+                      .uri(JSON_FILE_URI) 
+                      .headers(headers)
+                      .body(plainTextBody)
+                      .build(); 
+  }
+
+  private Request buildPatchRequestToJsonFileWithJsonPatchContent() {
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put(MessageHeader.CONTENT_TYPE, JSON_PATCH_TYPE);
+    String jsonPatchBody = "JSON PATCH BODY";
+    return new Request.Builder() 
+                      .method("PATCH") 
+                      .uri(JSON_FILE_URI) 
+                      .headers(headers)
+                      .body(jsonPatchBody)
+                      .build(); 
+  }
+}

--- a/src/test/java/JsonPatch/JsonPatchAddTest.java
+++ b/src/test/java/JsonPatch/JsonPatchAddTest.java
@@ -1,0 +1,31 @@
+import static org.junit.Assert.assertEquals; 
+import org.junit.Test; 
+
+public class JsonPatchAddTest {
+
+  @Test 
+  public void addsNewMemberIfTargetLocationDoesNotExist() throws BadRequestException, UnprocessableEntityException {
+    String original = "{ \"foo\": \"bar\"}";
+    JsonPatchAdd operation = new JsonPatchAdd("add", "/baz", "qux");
+    
+    String expectedString = "{" +
+                              "\"foo\":\"bar\"," +
+                              "\"baz\":\"qux\"" +
+                            "}";
+    String actualString = operation.applyOperation(original);
+    assertEquals(expectedString, actualString);
+  }
+
+  @Test 
+  public void replacesMemberIfTargetLocationExists() throws BadRequestException, UnprocessableEntityException {
+    String original = "{ \"foo\": \"bar\"}";
+    JsonPatchAdd operation = new JsonPatchAdd("add", "/foo", "buzz");
+    
+    String expectedString = "{" +
+                              "\"foo\":\"buzz\"" +
+                            "}";
+    String actualString = operation.applyOperation(original);
+    assertEquals(expectedString, actualString);
+  }
+
+}

--- a/src/test/java/JsonPatch/JsonPatchCopyTest.java
+++ b/src/test/java/JsonPatch/JsonPatchCopyTest.java
@@ -1,0 +1,45 @@
+import static org.junit.Assert.assertEquals; 
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.Test; 
+
+public class JsonPatchCopyTest {
+  private final static String FIRST_KEY = "\"firstKey\"";
+  private final static String FIRST_VALUE = "\"firstValue\"";
+  private final static String OP = "move";
+  private final static String ORIGINAL_JSON = crateJsonBodyStringWithNewLines();
+  private final static String NEW_KEY = "\"newKey\"";
+  
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();  
+
+  @Test 
+  public void throwsUnprocessableEntityExceptionIfFromLocationDoesNotExist() throws BadRequestException, UnprocessableEntityException {
+    String from = "/target/that/does/not/exist";
+    String path = "/firstKey";
+    JsonPatchOperation jsonPatch = new JsonPatchCopy(OP, from, path);
+
+    thrown.expect(UnprocessableEntityException.class);
+    jsonPatch.applyOperation(ORIGINAL_JSON);
+  }
+
+  @Test 
+  public void appliesCopyOperation() throws BadRequestException, UnprocessableEntityException {
+    String from = "/firstKey";
+    String path = "/newKey";
+    JsonPatchOperation operation = new JsonPatchCopy(OP, from, path);
+    
+    String expectedJson = "{" +
+                              NEW_KEY + ":" + FIRST_VALUE + "," + 
+                              FIRST_KEY + ":" + FIRST_VALUE  + 
+                            "}";
+    assertEquals(expectedJson, operation.applyOperation(ORIGINAL_JSON));
+  }
+
+  private static String crateJsonBodyStringWithNewLines() {
+    return "{\n" +
+              FIRST_KEY + ": " + FIRST_VALUE + "\n" + 
+            "}";
+  }
+    
+}

--- a/src/test/java/JsonPatch/JsonPatchMoveTest.java
+++ b/src/test/java/JsonPatch/JsonPatchMoveTest.java
@@ -1,0 +1,46 @@
+import static org.junit.Assert.assertEquals; 
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.Test; 
+
+public class JsonPatchMoveTest {
+  private final static String FIRST_KEY = "\"firstKey\"";
+  private final static String FIRST_VALUE = "\"firstValue\"";
+  private final static String OP = "move";
+  private final static String ORIGINAL_JSON = crateJsonBodyStringWithNewLines();
+  private final static String WILL_BE_MOVED_KEY = "willBeMovedKey";
+  private final static String WILL_BE_MOVED_VALUE = "\"willBeMovedValue\"";
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();  
+
+  @Test 
+  public void throwsUnprocessableEntityExceptionIfTargetLocationDoesNotExist() throws BadRequestException, UnprocessableEntityException {
+    String from = "/target/that/does/not/exist";
+    String path = "/firstKey";
+    JsonPatchOperation jsonPatch = new JsonPatchMove(OP, from, path);
+
+    thrown.expect(UnprocessableEntityException.class);
+    jsonPatch.applyOperation(ORIGINAL_JSON);
+  }
+    
+  @Test 
+  public void appliesMoveOperation() throws BadRequestException, UnprocessableEntityException {
+    String from = "/willBeMovedKey";
+    String path = "/firstKey";
+    JsonPatchOperation operation = new JsonPatchMove(OP, from, path);
+    
+    String expectedJson = "{" +
+                              FIRST_KEY + ":" + WILL_BE_MOVED_VALUE  +
+                            "}";
+    assertEquals(expectedJson, operation.applyOperation(ORIGINAL_JSON));
+  }
+
+  private static String crateJsonBodyStringWithNewLines() {
+    return "{\n" +
+              FIRST_KEY + ": " + FIRST_VALUE + ",\n" +
+              WILL_BE_MOVED_KEY + ": " + WILL_BE_MOVED_VALUE + "\n" +
+            "}";
+  }
+  
+}

--- a/src/test/java/JsonPatch/JsonPatchParserTest.java
+++ b/src/test/java/JsonPatch/JsonPatchParserTest.java
@@ -1,0 +1,93 @@
+// import java.util.ArrayList;
+// import static org.junit.Assert.assertEquals; 
+// import org.junit.BeforeClass;
+// import org.junit.Rule;
+// import org.junit.rules.ExpectedException;
+// import org.junit.Test; 
+
+// public class JsonPatchParserTest {
+//   private final static String JSON_PATCH_BODY = createJsonPatchBodyWithTwoPatches();
+
+//   private static JsonPatchParser parser;
+  
+//   @BeforeClass
+//   public static void setUp () {
+//     parser = new JsonPatchParser();
+//   }
+
+//   @Rule
+//   public ExpectedException thrown = ExpectedException.none();  
+
+//   @Test 
+//   public void throwsBadRequestExceptionWhenNotGivenAnArrayOfOperations() throws BadRequestException {
+//     String body = "{ \"op\": \"add\", \"path\": \"/a/b\" }";
+
+//     thrown.expect(BadRequestException.class);
+//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+//   }
+
+//   @Test 
+//   public void throwsBadRequestExceptionWithMissingOp() throws BadRequestException {
+//     String body = createJsonPatchBodyMissingOp();
+
+//     thrown.expect(BadRequestException.class);
+//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+//   }
+
+//   @Test 
+//   public void throwsBadRequestExceptionWithInvalidOp() throws BadRequestException {
+//     String body = createJsonPatchBodyWithInvalidOp();
+
+//     thrown.expect(BadRequestException.class);
+//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+//   }
+
+//   @Test 
+//   public void throwsBadRequestExceptionWithMissingPath() throws BadRequestException {
+//     String body = createJsonPatchBodyMissingPath();
+
+//     thrown.expect(BadRequestException.class);
+//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+//   }
+
+//   @Test 
+//   public void parsesSinglePatch() throws BadRequestException {
+//     String body = createJsonPatchBodyWithOnePatch();
+//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+//     assertEquals(1, jsonPatches.size());
+//   }
+
+//   @Test 
+//   public void parsesMultiplePatches() throws BadRequestException {
+//     String body = createJsonPatchBodyWithTwoPatches();
+//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+//     assertEquals(2, jsonPatches.size());
+//   }
+  
+//   private static String createJsonPatchBodyMissingOp() {
+//     return 
+//     "[{ \"notOp\": \"remove\", \"path\": \"/a/b\" }]";
+//   }
+
+//   private static String createJsonPatchBodyWithInvalidOp() {
+//     return 
+//     "[{ \"op\": \"invalidOp\", \"path\": \"/a/b\" }]";
+//   }
+
+//   private static String createJsonPatchBodyMissingPath() {
+//     return 
+//     "[{ \"notOp\": \"remove\", \"path\": \"/a/b\" }]";
+//   }
+
+//   private static String createJsonPatchBodyWithOnePatch() {
+//     return 
+//     "[{ \"op\": \"remove\", \"path\": \"/a/b\" }]";
+//   }
+
+//   private static String createJsonPatchBodyWithTwoPatches() {
+//     return 
+//     "[{ \"op\": \"remove\", \"path\": \"/a/b\" }," +
+//      "{ \"op\": \"add\", \"path\": \"/a/b\", \"value\": \"bar\" }]";
+//   }
+
+// }

--- a/src/test/java/JsonPatch/JsonPatchParserTest.java
+++ b/src/test/java/JsonPatch/JsonPatchParserTest.java
@@ -1,93 +1,93 @@
-// import java.util.ArrayList;
-// import static org.junit.Assert.assertEquals; 
-// import org.junit.BeforeClass;
-// import org.junit.Rule;
-// import org.junit.rules.ExpectedException;
-// import org.junit.Test; 
+import java.util.ArrayList;
+import static org.junit.Assert.assertEquals; 
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.Test; 
 
-// public class JsonPatchParserTest {
-//   private final static String JSON_PATCH_BODY = createJsonPatchBodyWithTwoPatches();
+public class JsonPatchParserTest {
+  private final static String JSON_PATCH_BODY = createJsonPatchBodyWithTwoPatches();
 
-//   private static JsonPatchParser parser;
+  private static JsonPatchParser parser;
   
-//   @BeforeClass
-//   public static void setUp () {
-//     parser = new JsonPatchParser();
-//   }
+  @BeforeClass
+  public static void setUp () {
+    parser = new JsonPatchParser();
+  }
 
-//   @Rule
-//   public ExpectedException thrown = ExpectedException.none();  
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();  
 
-//   @Test 
-//   public void throwsBadRequestExceptionWhenNotGivenAnArrayOfOperations() throws BadRequestException {
-//     String body = "{ \"op\": \"add\", \"path\": \"/a/b\" }";
+  @Test 
+  public void throwsBadRequestExceptionWhenNotGivenAnArrayOfOperations() throws BadRequestException {
+    String body = "{ \"op\": \"add\", \"path\": \"/a/b\" }";
 
-//     thrown.expect(BadRequestException.class);
-//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
-//   }
+    thrown.expect(BadRequestException.class);
+    ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+  }
 
-//   @Test 
-//   public void throwsBadRequestExceptionWithMissingOp() throws BadRequestException {
-//     String body = createJsonPatchBodyMissingOp();
+  @Test 
+  public void throwsBadRequestExceptionWithMissingOp() throws BadRequestException {
+    String body = createJsonPatchBodyMissingOp();
 
-//     thrown.expect(BadRequestException.class);
-//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
-//   }
+    thrown.expect(BadRequestException.class);
+    ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+  }
 
-//   @Test 
-//   public void throwsBadRequestExceptionWithInvalidOp() throws BadRequestException {
-//     String body = createJsonPatchBodyWithInvalidOp();
+  @Test 
+  public void throwsBadRequestExceptionWithInvalidOp() throws BadRequestException {
+    String body = createJsonPatchBodyWithInvalidOp();
 
-//     thrown.expect(BadRequestException.class);
-//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
-//   }
+    thrown.expect(BadRequestException.class);
+    ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+  }
 
-//   @Test 
-//   public void throwsBadRequestExceptionWithMissingPath() throws BadRequestException {
-//     String body = createJsonPatchBodyMissingPath();
+  @Test 
+  public void throwsBadRequestExceptionWithMissingPath() throws BadRequestException {
+    String body = createJsonPatchBodyMissingPath();
 
-//     thrown.expect(BadRequestException.class);
-//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
-//   }
+    thrown.expect(BadRequestException.class);
+    ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+  }
 
-//   @Test 
-//   public void parsesSinglePatch() throws BadRequestException {
-//     String body = createJsonPatchBodyWithOnePatch();
-//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
-//     assertEquals(1, jsonPatches.size());
-//   }
+  @Test 
+  public void parsesSinglePatch() throws BadRequestException {
+    String body = createJsonPatchBodyWithOnePatch();
+    ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+    assertEquals(1, jsonPatches.size());
+  }
 
-//   @Test 
-//   public void parsesMultiplePatches() throws BadRequestException {
-//     String body = createJsonPatchBodyWithTwoPatches();
-//     ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
-//     assertEquals(2, jsonPatches.size());
-//   }
+  @Test 
+  public void parsesMultiplePatches() throws BadRequestException {
+    String body = createJsonPatchBodyWithTwoPatches();
+    ArrayList<JsonPatchOperation> jsonPatches = parser.getOperations(body);
+    assertEquals(2, jsonPatches.size());
+  }
   
-//   private static String createJsonPatchBodyMissingOp() {
-//     return 
-//     "[{ \"notOp\": \"remove\", \"path\": \"/a/b\" }]";
-//   }
+  private static String createJsonPatchBodyMissingOp() {
+    return 
+    "[{ \"notOp\": \"remove\", \"path\": \"/a/b\" }]";
+  }
 
-//   private static String createJsonPatchBodyWithInvalidOp() {
-//     return 
-//     "[{ \"op\": \"invalidOp\", \"path\": \"/a/b\" }]";
-//   }
+  private static String createJsonPatchBodyWithInvalidOp() {
+    return 
+    "[{ \"op\": \"invalidOp\", \"path\": \"/a/b\" }]";
+  }
 
-//   private static String createJsonPatchBodyMissingPath() {
-//     return 
-//     "[{ \"notOp\": \"remove\", \"path\": \"/a/b\" }]";
-//   }
+  private static String createJsonPatchBodyMissingPath() {
+    return 
+    "[{ \"notOp\": \"remove\", \"path\": \"/a/b\" }]";
+  }
 
-//   private static String createJsonPatchBodyWithOnePatch() {
-//     return 
-//     "[{ \"op\": \"remove\", \"path\": \"/a/b\" }]";
-//   }
+  private static String createJsonPatchBodyWithOnePatch() {
+    return 
+    "[{ \"op\": \"remove\", \"path\": \"/a/b\" }]";
+  }
 
-//   private static String createJsonPatchBodyWithTwoPatches() {
-//     return 
-//     "[{ \"op\": \"remove\", \"path\": \"/a/b\" }," +
-//      "{ \"op\": \"add\", \"path\": \"/a/b\", \"value\": \"bar\" }]";
-//   }
+  private static String createJsonPatchBodyWithTwoPatches() {
+    return 
+    "[{ \"op\": \"remove\", \"path\": \"/a/b\" }," +
+     "{ \"op\": \"add\", \"path\": \"/a/b\", \"value\": \"bar\" }]";
+  }
 
-// }
+}

--- a/src/test/java/JsonPatch/JsonPatchRemoveTest.java
+++ b/src/test/java/JsonPatch/JsonPatchRemoveTest.java
@@ -1,0 +1,44 @@
+import static org.junit.Assert.assertEquals; 
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.Test; 
+
+public class JsonPatchRemoveTest {
+  private final static String FIRST_KEY = "\"firstKey\"";
+  private final static String FIRST_VALUE = "\"firstValue\"";
+  private final static String OP = "remove";
+  private final static String ORIGINAL_JSON = crateJsonBodyStringWithNewLines();
+  private final static String WILL_BE_REMOVED_KEY = "willBeRemovedKey";
+  private final static String WILL_BE_REMOVED_VALUE = "\"willBeRemovedValue\"";
+    
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();  
+
+  @Test 
+  public void throwsUnprocessableEntityExceptionIfTargetLocationDoesNotExist() throws BadRequestException, UnprocessableEntityException {
+    String path = "/target/that/does/not/exist";
+    JsonPatchOperation jsonPatch = new JsonPatchRemove(OP, path);
+
+    thrown.expect(UnprocessableEntityException.class);
+    jsonPatch.applyOperation(ORIGINAL_JSON);
+  }
+  
+  @Test 
+  public void removesTheValueAtTargetLocation() throws BadRequestException, UnprocessableEntityException {
+    String path = "/willBeRemovedKey";
+    JsonPatchOperation jsonPatch = new JsonPatchRemove(OP, path);
+    
+    String expectedJson = "{" +
+                              FIRST_KEY + ":" + FIRST_VALUE  +
+                            "}";
+    assertEquals(expectedJson, jsonPatch.applyOperation(ORIGINAL_JSON));
+  }
+
+  private static String crateJsonBodyStringWithNewLines() {
+    return "{\n" +
+              FIRST_KEY + ": " + FIRST_VALUE + ",\n" +
+              WILL_BE_REMOVED_KEY + ": " + WILL_BE_REMOVED_VALUE + "\n" +
+            "}";
+  }
+
+}

--- a/src/test/java/JsonPatch/JsonPatchReplaceTest.java
+++ b/src/test/java/JsonPatch/JsonPatchReplaceTest.java
@@ -1,0 +1,40 @@
+import static org.junit.Assert.assertEquals; 
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.Test; 
+
+public class JsonPatchReplaceTest {
+  private final static String FIRST_KEY = "\"firstKey\"";
+  private final static String FIRST_VALUE = "\"firstValue\"";
+  private final static String OP = "replace";
+  private final static String ORIGINAL_JSON = crateJsonBodyStringWithNewLines();
+  private final static String REPLACE_VALUE = "willBeReplacingFirstKey";
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();  
+
+  @Test 
+  public void throwsUnprocessableEntityExceptionIfTargetLocationDoesNotExist() throws BadRequestException, UnprocessableEntityException {
+    String path = "/target/that/does/not/exist";
+    JsonPatchOperation jsonPatch = new JsonPatchReplace(OP, path, FIRST_VALUE);
+
+    thrown.expect(UnprocessableEntityException.class);
+    jsonPatch.applyOperation(ORIGINAL_JSON);
+  }
+  
+  @Test 
+  public void appliesReplaceOperation() throws BadRequestException, UnprocessableEntityException {
+    String path = "/firstKey";
+    JsonPatchOperation operation = new JsonPatchReplace(OP, path, REPLACE_VALUE);
+    
+    String expectedJson = "{" + FIRST_KEY + ":" + "\"" + REPLACE_VALUE + "\""  + "}";
+    assertEquals(expectedJson, operation.applyOperation(ORIGINAL_JSON));
+  }
+
+  private static String crateJsonBodyStringWithNewLines() {
+    return "{\n" +
+              FIRST_KEY + ": " + FIRST_VALUE + ",\n" +
+            "}";
+  }
+  
+}

--- a/src/test/java/Logger/LoggerTest.java
+++ b/src/test/java/Logger/LoggerTest.java
@@ -40,13 +40,11 @@ public class LoggerTest {
   
   @Test
   public void createsNewLogFileWithTimeStampAsName() {    
-    System.out.println("first test");
     assertTrue(logFile.exists());
   }  
 
   @Test 
   public void logsEntryToLogFile() throws IOException, LoggerException {
-    System.out.println("second test");
     String entry = "This line will be written in the log.";
     logger.logEntry(entry);
     byte[] logBytes = readFile(logFileName);

--- a/src/test/java/Mock/MockDirectory.java
+++ b/src/test/java/Mock/MockDirectory.java
@@ -15,6 +15,13 @@ public class MockDirectory extends Directory {
     super(DEFAULT_DIRECTORY_PATH);
   }
   
+  public MockDirectory(List<String> files, HashMap fileContents, Map fileTypes) throws NonexistentDirectoryException {
+    super(DEFAULT_DIRECTORY_PATH);
+    this.files = files;
+    this.fileContents = fileContents;
+    this.fileTypes = fileTypes;
+  }
+
   public MockDirectory(List<String> subdirectories, List<String> files, HashMap fileContents, Map fileTypes) throws NonexistentDirectoryException {
     super(DEFAULT_DIRECTORY_PATH);
     this.subdirectories = subdirectories;
@@ -57,6 +64,11 @@ public class MockDirectory extends Directory {
 
   public boolean overwriteFileWithContent(String uri, byte[] content) {
     this.fileContents.replace(uri, content.toString());
+    return true;
+  }
+
+  public boolean overwriteFileWithStringContent(String uri, String content) {
+    this.fileContents.replace(uri, content);
     return true;
   }
 

--- a/src/test/java/Mock/MockDirectory.java
+++ b/src/test/java/Mock/MockDirectory.java
@@ -63,7 +63,7 @@ public class MockDirectory extends Directory {
   }
 
   public boolean overwriteFileWithContent(String uri, byte[] content) {
-    this.fileContents.replace(uri, content.toString());
+    this.fileContents.replace(uri, new String(content));
     return true;
   }
 

--- a/src/test/java/Mock/MockJsonPatchOperation.java
+++ b/src/test/java/Mock/MockJsonPatchOperation.java
@@ -1,0 +1,17 @@
+import java.util.ArrayList;
+
+public class MockJsonPatchOperation extends JsonPatchOperation {
+  private String contentToReturn;
+
+  public MockJsonPatchOperation(String contentToReturn) {
+    super("mockOp", "mockPath");
+    this.contentToReturn = contentToReturn;
+  }
+  
+  @Override 
+  public String applyOperation(String original) {
+    return contentToReturn;
+  }
+  
+}
+

--- a/src/test/java/Mock/MockJsonPatchParser.java
+++ b/src/test/java/Mock/MockJsonPatchParser.java
@@ -1,0 +1,14 @@
+import java.util.ArrayList;
+
+public class MockJsonPatchParser extends JsonPatchParser {
+  private ArrayList<JsonPatchOperation>  mockOperations;
+
+  public MockJsonPatchParser(ArrayList<JsonPatchOperation>  mockOperations) {
+    this.mockOperations = mockOperations;
+  }
+  
+  public ArrayList<JsonPatchOperation> getOperations(String body) throws BadRequestException {    
+    return this.mockOperations;
+  } 
+
+}

--- a/src/test/java/Request/RequestParserTest.java
+++ b/src/test/java/Request/RequestParserTest.java
@@ -14,6 +14,7 @@ public class RequestParserTest {
   private final static String CONTENT_TYPE = "application/x-www-form-urlencoded";
   private final static String MESSAGE_BODY = "hello=world&hola=mundo";
   private final static String METHOD = "POST";
+  private final static String OVERRIDE_METHOD = "OVERRIDE";
   private final static String URI = "/some-form.html";
 
   private static Request request;
@@ -33,8 +34,17 @@ public class RequestParserTest {
   }
 
   @Test
+  public void parsesMethodWhenOverridenWithMethodOverride() throws BadRequestException {
+    String requestString = createRequestStringWithOverride();
+    BufferedReader reader = createReaderFromString(requestString);
+    RequestParser requestParser = new RequestParser(reader);
+    Request request = requestParser.generateRequest();
+    assertEquals(OVERRIDE_METHOD, request.getMethod());
+  }
+
+  @Test
   public void parsesHeaders() {
-    assertEquals("application/x-www-form-urlencoded", request.getHeader(MessageHeader.CONTENT_TYPE));
+    assertEquals(CONTENT_TYPE, request.getHeader(MessageHeader.CONTENT_TYPE));
   }
 
   @Test
@@ -62,6 +72,15 @@ public class RequestParserTest {
 
   private static String createRequestString() {
     return createRequestLine() + 
+           MessageHeader.CONTENT_TYPE + ": " + CONTENT_TYPE + "\r\n" +
+           MessageHeader.CONTENT_LENGTH + ": " + CONTENT_LENGTH + "\r\n" +
+           "\r\n" +
+           MESSAGE_BODY;
+  }
+
+  private static String createRequestStringWithOverride() {
+    return createRequestLine() + 
+           MessageHeader.METHOD_OVERRIDE + ": " + OVERRIDE_METHOD + "\r\n" +
            MessageHeader.CONTENT_TYPE + ": " + CONTENT_TYPE + "\r\n" +
            MessageHeader.CONTENT_LENGTH + ": " + CONTENT_LENGTH + "\r\n" +
            "\r\n" +

--- a/src/test/java/StepDefinitions/DirectoryStepDefs.java
+++ b/src/test/java/StepDefinitions/DirectoryStepDefs.java
@@ -10,10 +10,13 @@ import static org.junit.Assert.assertTrue;
 public class DirectoryStepDefs {
   private final static String TEST_DIRECTORY_PATH = System.getProperty("TEST_DIRECTORY_PATH"); 
 
+  private File file;
+
   @Given("^a file with the name (.+) exists in (.+)$")
   public void a_file_with_the_name_exists_in_the_root_directory(String fileName, String directoryUri) throws Throwable {
     File file = new File(getFileUri(fileName, directoryUri));
     file.createNewFile();
+    this.file = file;
     assertTrue(file.exists());
   }
 

--- a/src/test/java/StepDefinitions/DirectoryStepDefs.java
+++ b/src/test/java/StepDefinitions/DirectoryStepDefs.java
@@ -7,6 +7,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
+import java.io.FileOutputStream;
+
+
 public class DirectoryStepDefs {
   private final static String TEST_DIRECTORY_PATH = System.getProperty("TEST_DIRECTORY_PATH"); 
 
@@ -25,6 +28,14 @@ public class DirectoryStepDefs {
     File file = new File(getFileUri(fileName, directoryUri));
     if (file.exists()) file.delete();
     assertFalse(file.exists());
+  }
+
+  @Given("^the file contains the content$")
+  public void the_file_contains_the_content(String content) throws Throwable {
+    System.out.println("PATH OF FILE TO BE CREATEDL " + this.file.getPath());
+    byte[] contentBytes = content.getBytes();
+    FileOutputStream outputStream = new FileOutputStream(this.file);
+    outputStream.write(contentBytes);
   }
 
   @Given("^a directory (.+) exists$")

--- a/src/test/java/StepDefinitions/RequestStepDefs.java
+++ b/src/test/java/StepDefinitions/RequestStepDefs.java
@@ -35,18 +35,10 @@ public class RequestStepDefs {
     this.world.con.setDoOutput(true);
   }
 
-  @When("^the request contains the application/json message body$")
-  public void the_request_contains_the_application_json_message_body() throws Throwable {
-    this.world.con.setRequestProperty("Content-Type", "application/json");
-
-    String json = "{ \"sampleKey\": \"sampleValue\", \"anotherSampleKey\": \"anotherSampleValue\" }";
-    writeString(this.world.con, json);
-  }
-
-  @When("^the request contains the (.+) message body \"([^\"]*)\"$")
-  public void the_request_contains_the_message_body(String contentType, String body) throws Throwable {
+  @When("^the request contains the (.+) message body$")
+  public void the_request_contains_the_message_body_block(String contentType, String content) throws Throwable {
     this.world.con.setRequestProperty("Content-Type", contentType);
-    writeString(this.world.con, body);
+    writeString(this.world.con, content);
   }
 
   private void writeString(HttpURLConnection con, String str) throws IOException {

--- a/src/test/java/StepDefinitions/RequestStepDefs.java
+++ b/src/test/java/StepDefinitions/RequestStepDefs.java
@@ -14,13 +14,24 @@ public class RequestStepDefs {
     this.world = world;
   }
 
-  @When("^a client makes a ([A-Z]+) request to (.+)$")
-  public void a_client_makes_a_HEAD_request_to(String method, String uri) throws Throwable {
+  // must not match PATCH request becuase PATCH requires X-HTTP-Method-Override for HttpURLConnection to make request
+  @When("^a client makes a (?!PATCH)([A-Z]+) request to (.+)$")
+  public void a_client_makes_a_request_to(String method, String uri) throws Throwable {
     this.world.requestUri = uri;
     String urlString = String.format("http://localhost:%d%s", PORT, uri);
     URL url = new URL(urlString);
     this.world.con = (HttpURLConnection) url.openConnection();
     this.world.con.setRequestMethod(method);
+    this.world.con.setDoOutput(true);
+  }
+
+  @When("^a client makes a PATCH request to (.+)$")
+  public void a_client_makes_a_PATCH_request_to(String uri) throws Throwable {
+    this.world.requestUri = uri;
+    String urlString = String.format("http://localhost:%d%s", PORT, uri);
+    URL url = new URL(urlString);
+    this.world.con = (HttpURLConnection) url.openConnection();
+    this.world.con.setRequestProperty("X-HTTP-Method-Override", "PATCH");
     this.world.con.setDoOutput(true);
   }
 
@@ -33,7 +44,7 @@ public class RequestStepDefs {
   }
 
   @When("^the request contains the (.+) message body \"([^\"]*)\"$")
-  public void the_request_contains_the_text_plain_message_body(String contentType, String body) throws Throwable {
+  public void the_request_contains_the_message_body(String contentType, String body) throws Throwable {
     this.world.con.setRequestProperty("Content-Type", contentType);
     writeString(this.world.con, body);
   }

--- a/src/test/resources/features/createResource.feature
+++ b/src/test/resources/features/createResource.feature
@@ -6,17 +6,26 @@ Background:
 Scenario: POST request with JSON
   When a client makes a POST request to /api/people
   And the request contains the application/json message body
+  """
+  { "aKey": "aValue" }
+  """
   Then the server should respond with status code 201 Created
   And the response should contain the header Location
 
 Scenario: POST request with plain text  
   When a client makes a POST request to /api/people
-  And the request contains the text/plain message body "plain text body"
+  And the request contains the text/plain message body
+  """
+  plain text body
+  """
   Then the server should respond with status code 201 Created
   And the response should contain the header Location
   
 Scenario: POST request with unsupported content type
   When a client makes a POST request to /api/people
-  And the request contains the unsupported/type message body "this type is not supported"
+  And the request contains the unsupported/type message body 
+  """
+  this type is not supported
+  """
   Then the server should respond with status code 415 Unsupported Media Type
   

--- a/src/test/resources/features/modifyResource.feature
+++ b/src/test/resources/features/modifyResource.feature
@@ -3,13 +3,19 @@ Feature: Modify a resource
 Scenario: PUT request to resource that does not exist
   Given a file with the name will-be-created-and-modified.txt does not exist in /
   When a client makes a PUT request to /will-be-created-and-modified.txt
-  And the request contains the text/plain message body "plain text body"
+  And the request contains the text/plain message body 
+  """
+  plain text body
+  """
   Then the server should respond with status code 201 Created
   And a file with the name will-be-created-and-modified.txt exists in /
 
 Scenario: PUT request to resource that does exist
   Given a file with the name will-be-created-and-modified.txt exists in /
   When a client makes a PUT request to /will-be-created-and-modified.txt
-  And the request contains the text/plain message body "modification to plain text body"
+  And the request contains the text/plain message body
+  """
+  modification to plain text body
+  """
   Then the server should respond with status code 200 OK
   And the file with the name will-be-created-and-modified.txt in / should contain the content "modification to plain text body"

--- a/src/test/resources/features/patch.feature
+++ b/src/test/resources/features/patch.feature
@@ -14,15 +14,3 @@ Scenario: Resource not found
   When a client makes a PATCH request to /does-not-exist.json
   And the request contains the application/json message body 
   Then the server should respond with status code 404 Not Found
-
-# Scenario: PATCH request to JSON resource 
-# When a client makes a PATCH request to /will-be-patched.json
-# And the request contains the application/json message body {
-#   "key": "newValue"
-# }
-# Then the server should respond with status code 200 OK 
-# And the server should respond with a message body of "{
-#   "key": "newValue",
-#   "anotherKey": "anotherOriginalValue"
-
-# }"

--- a/src/test/resources/features/patch.feature
+++ b/src/test/resources/features/patch.feature
@@ -1,11 +1,20 @@
 Feature: Update a resource with PATCH request 
 
 Background:
-Given a file with the name will-be-patched exists in /
+  Given a file with the name will-be-patched.json exists in /
+  And the file contains the content 
+  """
+  {
+    "aKey": "aValue"
+  }
+  """
 
 Scenario: Unsupported PATCH document
   When a client makes a PATCH request to /will-be-patched.json
-  And the request contains the text/plain message body "plain text patch"
+  And the request contains the text/plain message body 
+  """
+  plain text patch
+  """
   Then the server should respond with status code 415 Unsupported Media Type
   And the server should respond with the header Accept-Patch application/json-patch+json
 
@@ -13,4 +22,22 @@ Scenario: Resource not found
   Given a file with the name does-not-exist.json does not exist in /
   When a client makes a PATCH request to /does-not-exist.json
   And the request contains the application/json message body 
+  """
+  { "anotherKey": "anotherValue" }
+  """
   Then the server should respond with status code 404 Not Found
+
+Scenario: PATCH request to JSON resource 
+  When a client makes a PATCH request to /will-be-patched.json
+  And the request contains the application/json-patch+json message body 
+    """
+    [
+      { "op": "add", "path": "/addedKey", "value": "addedValue" },
+      { "op": "remove", "path": "/aKey" }
+    ]
+    """
+  Then the server should respond with status code 200 OK 
+  And the server should respond with a message body of
+  """
+  {"addedKey":"addedValue"}
+  """

--- a/src/test/resources/features/patch.feature
+++ b/src/test/resources/features/patch.feature
@@ -1,0 +1,28 @@
+Feature: Update a resource with PATCH request 
+
+Background:
+Given a file with the name will-be-patched exists in /
+
+Scenario: Unsupported PATCH document
+  When a client makes a PATCH request to /will-be-patched.json
+  And the request contains the text/plain message body "plain text patch"
+  Then the server should respond with status code 415 Unsupported Media Type
+  And the server should respond with the header Accept-Patch application/json-patch+json
+
+Scenario: Resource not found 
+  Given a file with the name does-not-exist.json does not exist in /
+  When a client makes a PATCH request to /does-not-exist.json
+  And the request contains the application/json message body 
+  Then the server should respond with status code 404 Not Found
+
+# Scenario: PATCH request to JSON resource 
+# When a client makes a PATCH request to /will-be-patched.json
+# And the request contains the application/json message body {
+#   "key": "newValue"
+# }
+# Then the server should respond with status code 200 OK 
+# And the server should respond with a message body of "{
+#   "key": "newValue",
+#   "anotherKey": "anotherOriginalValue"
+
+# }"


### PR DESCRIPTION
## Router 
Before completing this feature, I discussed ways of refactoring PATCH logic out of `FileHandler`. Keeping the logic inside of `FileHandler` would have given the Handler multiple reasons to change: 1) when supporting new methods and 2) when supporting new PATCH file types. Jayden suggested routing requests based on both their method and their URI rather than just their URI. Because I didn't want to get too sidetracked--and because the feature seems closely related to `#24: `ft/support-OPTIONS-method`--I simply added a conditional inside of `#getResponse`, which checks to see if the request contains the PATCH method. If it does, it routes the request to `PatchHandler`. 

## PatchHandler
To allow mocking the `JsonPatchParser`, I passed in an instance of `JsonPatchParser` as an argument to `PatchHandler`'s constructor. I understand that the argument list would quickly grow as the number of files that could be PATCHed (and the number of supported PATCH formats) grows. I think that I could pass in a map instead. That map would contain PATCH formats as keys and their corresponding parsers as values. However, I think that would start heading in the direction of potentially cumbersome interfaces, so I decided not to implement it for now. If I did have to expand the number of supported file types to patch, I would refactor this way. 

## JsonPatchParser
This class uses the `org.json` library to parse incoming JSON Patch request bodies. 

## JsonPatchOperation 
The individual implementations of each `JsonPatchOperation` also use the `org.json` library in order to manipulate the JSON resource content. 

This class exposes four protected methods to the child classes that extend this class. `#addValue`, `#removeValue` and `#getValueFromJsonObjectGivenKeys` are all recursive functions, and they contain a lot of similar code. Their base cases do vary slightly. Are there any patterns that might help abstract some of the similar code? 

## RequestParser
Since the `HttpURLConnection` class does not support sending PATCH requests, I had to update my `RequestParser` class. If the incoming request contains the `X-HTTP-Method-Override` header, the parser ignores the method in the request line and uses the value provided in the header instead. Under the hood, the request is actually being with the POST method.

## patch.feature
I was able to implement tests for unsupported PATCH documents and for resources that aren't found fairly easily. Unfortunately, I couldn't properly test PATCH requests to JSON files because I couldn't get the files to  
 (despite using code that is almost identical to a method I used in `Directory`). 

