### PR TITLE
Protect Routes with Authentication 

### DIFF
--- a/src/main/java/Authentication/Authenticator.java
+++ b/src/main/java/Authentication/Authenticator.java
@@ -1,0 +1,56 @@
+import java.util.Base64;
+import java.util.Base64.Decoder;
+import java.util.HashMap;
+import java.util.List;
+
+public class Authenticator {
+  private final static String USERNAME = "username";
+  private final static String PASSWORD = "password";
+  
+  private String authRoute;
+  private List<String> protectedUris;
+  
+  public Authenticator(List<String> protectedUris, String authRoute) {
+    this.protectedUris = protectedUris;
+    this.authRoute = authRoute;
+  }
+
+  public Request authenticateRequest(Request request) {
+    return isProtected(request.getURI()) ? validateCredentials(request) : request;
+  }
+
+  private boolean isProtected(String uri) {
+    return this.protectedUris.contains(uri);
+  }
+
+  private Request validateCredentials(Request request) {
+    String authHeader = request.getHeader(MessageHeader.AUTHORIZATION);
+    if (authHeader == null) {
+      return buildRequestToAuthRoute();
+    }
+
+    String[] splitDecodedCredentials = getSplitDecodedCredentials(authHeader);
+    return identicalCredentials(splitDecodedCredentials) ? request : buildRequestToAuthRoute();  
+  }
+
+  private String[] getSplitDecodedCredentials(String authHeader) {
+    String[] splitAuthHeader = authHeader.split(" ");
+    String encodedCredentials = splitAuthHeader[1];
+    Base64.Decoder decoder = Base64.getDecoder();
+    String decodedCredentials = new String(decoder.decode(encodedCredentials));
+    return decodedCredentials.split(":");
+  }
+
+  private boolean identicalCredentials(String[] splitDecodedCredentials) {
+    String username = splitDecodedCredentials[0];
+    String password = splitDecodedCredentials[1];
+    return username.equals(USERNAME) && password.equals(PASSWORD);
+  }
+
+  private Request buildRequestToAuthRoute() {
+    return new Request.Builder()
+                      .uri(authRoute)
+                      .build();
+  }
+  
+} 

--- a/src/main/java/Authentication/Authenticator.java
+++ b/src/main/java/Authentication/Authenticator.java
@@ -3,14 +3,13 @@ import java.util.Base64.Decoder;
 import java.util.HashMap;
 import java.util.List;
 
-public class Authenticator {
-  private final static String USERNAME = "username";
-  private final static String PASSWORD = "password";
-  
+public class Authenticator {  
   private String authRoute;
+  private Credentials credentials;
   private List<String> protectedUris;
   
-  public Authenticator(List<String> protectedUris, String authRoute) {
+  public Authenticator(Credentials credentials, List<String> protectedUris, String authRoute) {
+    this.credentials = credentials;
     this.protectedUris = protectedUris;
     this.authRoute = authRoute;
   }
@@ -44,7 +43,7 @@ public class Authenticator {
   private boolean identicalCredentials(String[] splitDecodedCredentials) {
     String username = splitDecodedCredentials[0];
     String password = splitDecodedCredentials[1];
-    return username.equals(USERNAME) && password.equals(PASSWORD);
+    return this.credentials.areValidCredentials(username, password);
   }
 
   private Request buildRequestToAuthRoute() {

--- a/src/main/java/Authentication/Authenticator.java
+++ b/src/main/java/Authentication/Authenticator.java
@@ -3,7 +3,7 @@ import java.util.Base64.Decoder;
 import java.util.HashMap;
 import java.util.List;
 
-public class Authenticator {  
+public class Authenticator extends Middleware {  
   private String authRoute;
   private Credentials credentials;
   private List<String> protectedUris;
@@ -14,7 +14,7 @@ public class Authenticator {
     this.authRoute = authRoute;
   }
 
-  public Request authenticateRequest(Request request) {
+  public Request applyMiddleware(Request request) {
     try {
       return isProtected(request.getURI()) ? validateCredentials(request) : request;
     } catch (NullPointerException e) {
@@ -23,7 +23,15 @@ public class Authenticator {
   }
 
   private boolean isProtected(String uri) {
-    return this.protectedUris.contains(uri);
+    return this.protectedUris.contains(uri) || isProtectedChild(uri);
+  }
+
+  private boolean isProtectedChild(String uri) {
+    for (String protectedUri : protectedUris) {
+      if (uri.matches(protectedUri + "/.+")) return true;
+    }
+
+    return false;
   }
 
   private Request validateCredentials(Request request) {

--- a/src/main/java/Authentication/Credentials.java
+++ b/src/main/java/Authentication/Credentials.java
@@ -1,3 +1,14 @@
 public class Credentials {
+  private String password;
+  private String username;
+  
+  public Credentials(String username, String password) {
+    this.username = username;
+    this.password = password;
+  }
 
+  public boolean areValidCredentials(String username, String password) {
+    return username.equals(this.username) && password.equals(this.password);
+  }
+  
 }

--- a/src/main/java/Authentication/Credentials.java
+++ b/src/main/java/Authentication/Credentials.java
@@ -1,0 +1,3 @@
+public class Credentials {
+
+}

--- a/src/main/java/ClientThread.java
+++ b/src/main/java/ClientThread.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class ClientThread implements Runnable {
   private Socket clientSocket; 
   private BufferedReader in;
@@ -23,8 +26,13 @@ public class ClientThread implements Runnable {
     try {
       initiateClient();
           
+      
       Request request = parseRequest();
       logRequest(request);
+
+      List<String> protectedUris = Arrays.asList( "/protected" );
+      // AuthMiddleware auth = new AuthMiddleware(protectedUris, router);
+      // Response response = auth.getResponse(request);
       Response response = this.router.getResponse(request);
       logResponse(response);
       byte[] formattedResponse = new ResponseFormatter(response).formatResponse();

--- a/src/main/java/Handler/AuthHandler.java
+++ b/src/main/java/Handler/AuthHandler.java
@@ -1,0 +1,10 @@
+public class AuthHandler implements Handler {
+  private final static String AUTH_SCHEME = "Basic";
+  
+  public Response generateResponse(Request request) {
+    return new Response.Builder(HttpStatusCode.UNAUTHORIZED)
+                       .setHeader(MessageHeader.AUTHENTICATE, AUTH_SCHEME)
+                       .build();
+  }
+
+}

--- a/src/main/java/HttpMethod.java
+++ b/src/main/java/HttpMethod.java
@@ -1,0 +1,20 @@
+import java.util.Arrays;
+import java.util.List;
+
+public class HttpMethod {
+  public final static String DELETE = "DELETE";
+  public final static String GET = "GET";
+  public final static String HEAD = "HEAD";
+  public final static String OPTIONS = "OPTIONS";
+  public final static String POST = "POST";
+  public final static String PUT = "PUT";
+
+  public static final List<String> SUPPORTED_METHODS = Arrays.asList( 
+    DELETE, 
+    GET, 
+    HEAD, 
+    POST, 
+    PUT
+  );
+
+}

--- a/src/main/java/Logger/Logger.java
+++ b/src/main/java/Logger/Logger.java
@@ -6,15 +6,36 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-public class Logger {
+public class Logger extends Middleware {
   private String dateTimePattern;
   private String logDirectoryPath;
   private File logFile;
+
+
+
+  LogFormatter logFormatter = new LogFormatter();
+
+
+
 
   public Logger(String logDirectoryPath, String dateTimePattern) throws LoggerException {
     this.logDirectoryPath = logDirectoryPath;
     this.dateTimePattern = dateTimePattern;
   }
+
+  public Request applyMiddleware(Request request) {
+    String requestFormattedForLogger = this.logFormatter.formatRequest(request);
+    logEntry(requestFormattedForLogger);
+    return checkNext(request);
+  }
+
+  public Response applyMiddleware(Response response) {
+    String responseFormattedForLogger = this.logFormatter.formatResponse(response);
+    logEntry(responseFormattedForLogger);
+    return checkNext(response);
+  }
+
+
 
   public File createLogFile() throws LoggerException {
     try {

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -60,6 +60,7 @@ public class Main {
     String rootPath = System.getProperty("user.dir");
     routes.put("/", new DirectoryHandler(directory));
     routes.put("/echo", new EchoHandler());
+    routes.put("/api/authenticate", new AuthHandler());
     routes.put("/api/form", new FormHandler(directory));
     routes.put("/api/people", new PeopleHandler(directory));
     routes.put("/api/query", new QueryHandler(new UrlDecoder()));

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,6 +1,9 @@
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
  
 public class Main {
+  private final static String AUTH_ROUTE = "/api/authenticate";
   private static final int DEFAULT_PORT_NUMBER = 8888;
   private static final String LOG_DIRECTORY_PATH = System.getProperty("user.dir") + "/logs";
   
@@ -17,7 +20,9 @@ public class Main {
       int port = parser.getPortNumberOrDefault(DEFAULT_PORT_NUMBER);
       Router router = setUpRouter(defaultHandler);
       Logger logger = setUpLogger();
-      Server server = new Server(port, router, logger);
+      Authenticator authenticator = setUpAuthenticator();
+      Middleware middleware = configureMiddleware(logger, authenticator);
+      Server server = new Server(port, router, middleware);
       server.start();
     } catch (ArrayIndexOutOfBoundsException e) {
       System.err.println(e.getMessage());
@@ -60,7 +65,7 @@ public class Main {
     String rootPath = System.getProperty("user.dir");
     routes.put("/", new DirectoryHandler(directory));
     routes.put("/echo", new EchoHandler());
-    routes.put("/api/authenticate", new AuthHandler());
+    routes.put(AUTH_ROUTE, new AuthHandler());
     routes.put("/api/form", new FormHandler(directory));
     routes.put("/api/people", new PeopleHandler(directory));
     routes.put("/api/query", new QueryHandler(new UrlDecoder()));
@@ -72,6 +77,14 @@ public class Main {
     Logger logger = new Logger(LOG_DIRECTORY_PATH, dateTimePattern);
     logger.createLogFile();
     return logger;
+  }
+
+  private static Authenticator setUpAuthenticator() {
+    Credentials credentials = new Credentials("username", "password");
+    List<String> protectedUris = Arrays.asList(
+      "/protected"
+    ); 
+    return new Authenticator(credentials, protectedUris, AUTH_ROUTE);
   }
 
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -87,4 +87,10 @@ public class Main {
     return new Authenticator(credentials, protectedUris, AUTH_ROUTE);
   }
 
+  private static Middleware configureMiddleware(Logger logger, Authenticator authenticator) {
+    Middleware middleware = logger;
+    middleware.linkWith(authenticator);
+    return middleware;
+  }
+
 }

--- a/src/main/java/MessageHeader.java
+++ b/src/main/java/MessageHeader.java
@@ -2,6 +2,9 @@ import java.io.UnsupportedEncodingException;
 
 public class MessageHeader {
   public final static String ACCEPT_PATCH = "Accept-Patch";
+  public final static String ALLOW = "Allow";
+  public final static String AUTHENTICATE = "WWW-Authenticate";
+  public final static String AUTHORIZATION = "Authorization";
   public final static String CONTENT_LENGTH = "Content-Length";
   public final static String CONTENT_TYPE = "Content-Type";
   public final static String LOCATION = "Location";

--- a/src/main/java/Middleware.java
+++ b/src/main/java/Middleware.java
@@ -1,0 +1,29 @@
+public abstract class Middleware {
+  private Middleware next;
+
+  public Middleware linkWith(Middleware next) {
+    this.next = next;
+    return next;
+  }
+
+  public abstract Request applyMiddleware(Request request);
+
+  public Response applyMiddleware(Response response) {
+    return response;
+  };
+
+  protected Request checkNext(Request request) {
+    if (next == null) {
+        return request;
+    }
+    return next.applyMiddleware(request);
+  }
+
+  protected Response checkNext(Response response) {
+    if (next == null) {
+        return response;
+    }
+    return next.applyMiddleware(response);
+  }
+
+}  

--- a/src/main/java/Response/HttpStatusCode.java
+++ b/src/main/java/Response/HttpStatusCode.java
@@ -6,6 +6,7 @@ public class HttpStatusCode {
   public static final int NO_CONTENT = 204;
   public static final int SEE_OTHER = 303;
   public static final int BAD_REQUEST= 400;
+  public static final int UNAUTHORIZED= 401;
   public static final int NOT_FOUND = 404;
   public static final int METHOD_NOT_ALLOWED = 405;
   public static final int UNSUPPORTED_MEDIA_TYPE = 415;
@@ -22,6 +23,7 @@ public class HttpStatusCode {
     Map.entry(NOT_FOUND, "Not Found"),
     Map.entry(SEE_OTHER, "See Other"),
     Map.entry(UNPROCESSABLE_ENTITY, "Unprocessable Entity"),
+    Map.entry(UNAUTHORIZED, "Unauthorized"),
     Map.entry(UNSUPPORTED_MEDIA_TYPE, "Unsupported Media Type")
   );
 

--- a/src/main/java/Server.java
+++ b/src/main/java/Server.java
@@ -6,15 +6,17 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 
 public class Server {
+  private Authenticator authenticator;
   private int port; 
   private Logger logger;
   private Router router;
   ServerSocket server;
 
-  public Server(int port, Router router, Logger logger) {
+  public Server(int port, Router router, Logger logger, Authenticator authenticator) {
     this.port = port;
     this.router = router;
     this.logger = logger;
+    this.authenticator = authenticator;
   }
 
   public void start() {
@@ -25,7 +27,7 @@ public class Server {
       ExecutorService executor = Executors.newCachedThreadPool();
       while (true) {
         Socket clientSocket = server.accept();
-        executor.execute(new ClientThread(clientSocket, this.router, logger));
+        executor.execute(new ClientThread(clientSocket, this.router, logger, this.authenticator));
       } 
     } catch (BindException e) {
       System.err.println("Port " + port + " is unavailable.");

--- a/src/main/java/Server.java
+++ b/src/main/java/Server.java
@@ -6,36 +6,30 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 
 public class Server {
-  private Authenticator authenticator;
+  private Middleware middleware; 
   private int port; 
-  private Logger logger;
   private Router router;
   ServerSocket server;
 
-  public Server(int port, Router router, Logger logger, Authenticator authenticator) {
+  public Server(int port, Router router, Middleware middleware) {
     this.port = port;
     this.router = router;
-    this.logger = logger;
-    this.authenticator = authenticator;
+    this.middleware = middleware;
   }
 
   public void start() {
     try {
       this.server = new ServerSocket(this.port);
       System.out.println("Listening on port " + this.port);
-      logger.logEntry("Server started on port " + this.port);
       ExecutorService executor = Executors.newCachedThreadPool();
       while (true) {
         Socket clientSocket = server.accept();
-        executor.execute(new ClientThread(clientSocket, this.router, logger, this.authenticator));
+        executor.execute(new ClientThread(clientSocket, this.router, this.middleware));
       } 
     } catch (BindException e) {
       System.err.println("Port " + port + " is unavailable.");
     } catch (IllegalArgumentException e) {
       System.err.println("Port number must be between 0 and 65535.");
-    } catch (IOException e) {
-      System.err.println(e);
-      System.err.println("Could not create logger");
     } catch (Exception e) {
       System.err.println(e);
       System.err.println("Error on port " + port);

--- a/src/test/java/Authentication/AuthenticatorTest.java
+++ b/src/test/java/Authentication/AuthenticatorTest.java
@@ -18,7 +18,8 @@ public class AuthenticatorTest {
   
   @BeforeClass
   public static void setUp() {
-    authenticator = new Authenticator(PROTECTED_URIS, AUTH_ROUTE);
+    Credentials credentials = new Credentials("username", "password");
+    authenticator = new Authenticator(credentials, PROTECTED_URIS, AUTH_ROUTE);
   }
   
   @Test 

--- a/src/test/java/Authentication/AuthenticatorTest.java
+++ b/src/test/java/Authentication/AuthenticatorTest.java
@@ -1,0 +1,68 @@
+import java.util.Arrays;
+import java.util.List;
+import static org.junit.Assert.assertEquals; 
+import org.junit.BeforeClass; 
+import org.junit.Test; 
+
+public class AuthenticatorTest {
+  private static final String AUTH_ROUTE = "/auth/route";
+  private static final String INVALID_ENCODED_CREDENTIALS= "aW52YWxpZHVzZXJuYW1lOmludmFsaWRwYXNzd29yZA0K";
+  private static final String PROTECTED_URI = "/protected/uri";
+  private static final List<String> PROTECTED_URIS = Arrays.asList(
+    PROTECTED_URI
+    );  
+    private static final String UNPROTECTED_URI = "/unprotected/uri";
+    private static final String VALID_ENCODED_CREDENTIALS= "dXNlcm5hbWU6cGFzc3dvcmQ=";
+
+  private static Authenticator authenticator;
+  
+  @BeforeClass
+  public static void setUp() {
+    authenticator = new Authenticator(PROTECTED_URIS, AUTH_ROUTE);
+  }
+  
+  @Test 
+  public void doesNotAlterRequestIfUriIsUnprotected() {
+    Request request = new Request.Builder()
+                                 .method(HttpMethod.GET)
+                                 .uri(UNPROTECTED_URI)
+                                 .build();
+    request = authenticator.authenticateRequest(request);
+    assertEquals(UNPROTECTED_URI, request.getURI());
+  }
+
+  @Test 
+  public void altersUnauthenticatedRequestIfUriIsProtected() {
+    Request request = new Request.Builder()
+                                 .method(HttpMethod.GET)
+                                 .uri(PROTECTED_URI)
+                                 .build();
+    request = authenticator.authenticateRequest(request);
+    assertEquals(AUTH_ROUTE, request.getURI());
+  }
+
+  @Test 
+  public void altersRequestWithInvalidCredentialstIfUriIsProtected() {
+    String authHeaderValue = "Basic " + INVALID_ENCODED_CREDENTIALS;
+    Request request = new Request.Builder()
+                        .method(HttpMethod.GET)
+                        .setHeader(MessageHeader.AUTHORIZATION, authHeaderValue)
+                        .uri(PROTECTED_URI)
+                        .build();
+    request = authenticator.authenticateRequest(request);
+    assertEquals(AUTH_ROUTE, request.getURI());
+  }
+  @Test 
+
+  public void doesNotAlterRequestWithValidCredentialstIfUriIsProtected() {
+    String authHeaderValue = "Basic " + VALID_ENCODED_CREDENTIALS;
+    Request request = new Request.Builder()
+                        .method(HttpMethod.GET)
+                        .setHeader(MessageHeader.AUTHORIZATION, authHeaderValue)
+                        .uri(PROTECTED_URI)
+                        .build();
+    request = authenticator.authenticateRequest(request);
+    assertEquals(PROTECTED_URI, request.getURI());
+  }
+
+}

--- a/src/test/java/Authentication/CredentialsTest.java
+++ b/src/test/java/Authentication/CredentialsTest.java
@@ -1,0 +1,10 @@
+import java.util.Arrays;
+import java.util.List;
+import static org.junit.Assert.assertEquals; 
+import org.junit.BeforeClass; 
+import org.junit.Test; 
+
+
+public class CredentialsTest {
+
+}

--- a/src/test/java/Authentication/CredentialsTest.java
+++ b/src/test/java/Authentication/CredentialsTest.java
@@ -1,10 +1,26 @@
-import java.util.Arrays;
-import java.util.List;
 import static org.junit.Assert.assertEquals; 
+import static org.junit.Assert.assertFalse; 
+import static org.junit.Assert.assertTrue; 
 import org.junit.BeforeClass; 
 import org.junit.Test; 
 
 
 public class CredentialsTest {
+  private final static String USERNAME = "clever_username";
+  private final static String PASSWORD = "secure_password";
+
+  private static Credentials credentials = new Credentials(USERNAME, PASSWORD);
+
+  @Test
+  public void returnsTrueWhenCredentialsMatch() {
+    assertTrue(credentials.areValidCredentials(USERNAME, PASSWORD));
+  }
+
+  @Test
+  public void returnsFalseWhenCredentialsDoNotMatch() {
+    String username = "nonexistent_useraname";
+    String password = "incorrect_password";
+    assertFalse(credentials.areValidCredentials(username, password));
+  }
 
 }

--- a/src/test/java/StepDefinitions/DirectoryStepDefs.java
+++ b/src/test/java/StepDefinitions/DirectoryStepDefs.java
@@ -53,7 +53,7 @@ public class DirectoryStepDefs {
   }
 
   private String getFileUri(String fileName, String directoryURI) {
-    return TEST_DIRECTORY_PATH + directoryURI + fileName;
+    return TEST_DIRECTORY_PATH + directoryURI + "/" + fileName;
   } 
 
 }

--- a/src/test/java/StepDefinitions/RequestHeaderStepDefs.java
+++ b/src/test/java/StepDefinitions/RequestHeaderStepDefs.java
@@ -1,0 +1,24 @@
+import cucumber.api.java.en.When;
+import cucumber.api.PendingException;
+import java.util.Base64;
+
+public class RequestHeaderStepDefs {
+  private World  world;
+
+  public RequestHeaderStepDefs(World world) { 
+    this.world = world;
+  }
+  
+  @When("^the client provides the credentials: (.+) (.+)$")
+  public void the_client_provides_the_credentials(String username, String password) throws Throwable {
+    String field = "Basic " + encodeCredentials(username, password);
+    this.world.con.setRequestProperty("Authorization", field);
+  }
+
+  private String encodeCredentials(String username, String password) {
+    String raw = username + ":" + password;
+    Base64.Encoder encoder = Base64.getEncoder(); 
+    return new String(encoder.encode(raw.getBytes()));
+  }
+
+}

--- a/src/test/java/StepDefinitions/ResponseHeaderStepDefs.java
+++ b/src/test/java/StepDefinitions/ResponseHeaderStepDefs.java
@@ -4,10 +4,10 @@ import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-public class HeaderStepDefs {
+public class ResponseHeaderStepDefs {
   private World world;
 
-  public HeaderStepDefs(World world) {
+  public ResponseHeaderStepDefs(World world) {
     this.world = world;
   }
 

--- a/src/test/resources/features/authRoutes.feature
+++ b/src/test/resources/features/authRoutes.feature
@@ -1,0 +1,19 @@
+Feature: Protect routes with  authentication
+
+Background:
+  Given a directory /protected exists
+  And a file with the name protected-file.txt exists in /protected
+ 
+Scenario: Request missing authenticatino header 
+  When a client makes a GET request to /protected
+  Then the server should respond with status code 401 Unauthorized
+
+Scenario: Request with valid username but invalid password 
+When a client makes a GET request to /protected
+And the client provides the credentials: username invalid_password
+Then the server should respond with status code 401 Unauthorized
+
+Scenario: Request with valid username and valid password 
+When a client makes a GET request to /protected
+And the client provides the credentials: username password
+Then the server should respond with status code 200 OK


### PR DESCRIPTION
## Middleware 
In order to avoid passing in many arguments to both the `Server` and `ClientThread` classes, I created the `Middleware` class, which uses the Chain of Responsibility pattern to pass a request and/or response through a chain of middleware. 

One concern that I have with this approach is that I've only created one `Middleware` chain for both `Request`s and `Response`s. Since the server only uses two `Middleware` classes (below), it seemed a bit excessive to create a separate `Middleware` chain for `Request`s and `Response`s since that would not decrease the number of arguments passed into `ClientThread` (which was the original motivation for this refactoring). The consequence is that I cannot differentiate the order of the chain between `Request`s and `Response`s. 

To avoid needing all `Middleware` classes to expose methods for both `Request`s and `Response`s, I did not make `applyMiddleware(Response response)` abstract. Instead, the method simply returns the `response` passed in to avoid any errors when a child class does not make use of the `response` object. 

## Logger
The `Logger` class now `extends Middleware` and exposes two methods: `applyMiddleware(Request request)` and `applyMiddleware(Response response)`. 

## Authenticator
This class also `extends Middleware` and exposes one method: `applyMiddleware(Request request)`. It is capable of "altering" a request if the original request URI targets protected route and the request is not authenticated. Because `Request`s are immutable once created due to the builder pattern, the class does the following. First, it determines if the target URI is protected. If it is not, it simply passes the `Request` to the next middleware. If it is protected, it determines if the user provided credentials. If they did not, it returns a new `Request` with a URI that points to the `AuthHandler`. This URI is passed in as a constructor argument. If the client provided invalid credentials, it returns a new `Request` with a URI that points to the `AuthHandler`. If the credentials are valid, then it passes the original `Request` to the next middleware.

## Credentials
The `Authenticator` class receives an instance of `Credentials` as a constructor parameter. The class exposes one method: `#areValidCredentials(String username, String password)`. 

I considered cleaning up the `Authenticator` class by possibly moving some of its logic into this class. Specifically, I considered moving the logic for comparing a base64-encoded username/password combination. However, that would couple the `Credentials` class to base-64 encoded credentials. I know that I can probably have extend or implement the Credentials class with a base-64 child class, but that seemed like a premature refactoring. 

## Main 
My `Main` class has gotten a little long with so much configuration happening. I think that I'd like to move some of the logic into a separate class or possibly into a configuration file, but I'm not entirely sure which would work better. Choosing which routes to protect seems like a fairly static operation, so it seems to me like those might belong in a static configuration file. However, choosing the username and password might be more dynamic, so I'm not entirely sure where to move that. 

## authRoutes.feature
On a related note, my acceptance tests for this feature are coupled to hard-coded credentials and routes. I can think of two solutions: 
1) Enable username/password configuration as a command-line argument. Once I eventually get the Cucumber tests to start the server, a step can choose the username and password against which to run assertions (e.g. `Given the user provides the following credentials: correct_username correct_password`)
2) I can create generic steps (such as `Given the user provides valid credentials`), and the step definitions can rely on hard-coded credentials and protected routes to correctly run the assertions. 