### PR TITLE
Support Cross Origin Resource Sharing 

### DIFF
--- a/src/main/java/CorsMiddleware.java
+++ b/src/main/java/CorsMiddleware.java
@@ -1,0 +1,14 @@
+import java.util.HashMap;
+
+public class CorsMiddleware extends Middleware {
+
+  public Response applyMiddleware(Response originalResponse) {
+    HashMap<String, String> headers = originalResponse.getHeaders();
+    headers.put(MessageHeader.AC_ALLOW_ORIGIN, "*");
+    return new Response.Builder(originalResponse.getStatusCode()) 
+                       .headers(originalResponse.getHeaders())
+                       .messageBody(originalResponse.getMessageBody())
+                       .build();
+  }
+
+}

--- a/src/main/java/CorsMiddleware.java
+++ b/src/main/java/CorsMiddleware.java
@@ -3,12 +3,14 @@ import java.util.HashMap;
 public class CorsMiddleware extends Middleware {
 
   public Response applyMiddleware(Response originalResponse) {
-    HashMap<String, String> headers = originalResponse.getHeaders();
-    headers.put(MessageHeader.AC_ALLOW_ORIGIN, "*");
-    return new Response.Builder(originalResponse.getStatusCode()) 
-                       .headers(originalResponse.getHeaders())
+    HashMap<String, String> updatedHeaders = originalResponse.getHeaders();
+    updatedHeaders.put(MessageHeader.AC_ALLOW_ORIGIN, "*");
+    Response updatedResponse = new Response.Builder(originalResponse.getStatusCode()) 
+                       .headers(updatedHeaders)
                        .messageBody(originalResponse.getMessageBody())
                        .build();
+
+    return checkNext(updatedResponse);
   }
 
 }

--- a/src/main/java/Handler/FileHandler.java
+++ b/src/main/java/Handler/FileHandler.java
@@ -51,7 +51,7 @@ import java.util.List;
 
   private boolean isPatchable(String uri) {
     String fileType = this.directory.getFileType(uri);
-    return fileType.equals(MimeType.JSON) || fileType.equals(MimeType.PLAIN_TEXT);
+    return fileType.equals(MimeType.JSON);
   }
 
   private boolean isPutable(String uri) {

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -19,9 +19,10 @@ public class Main {
  
       int port = parser.getPortNumberOrDefault(DEFAULT_PORT_NUMBER);
       Router router = setUpRouter(defaultHandler);
+      CorsMiddleware corsMiddleware = new CorsMiddleware();
       Logger logger = setUpLogger();
       Authenticator authenticator = setUpAuthenticator();
-      Middleware middleware = configureMiddleware(logger, authenticator);
+      Middleware middleware = configureMiddleware(corsMiddleware, logger, authenticator);
       Server server = new Server(port, router, middleware);
       server.start();
     } catch (ArrayIndexOutOfBoundsException e) {
@@ -88,9 +89,10 @@ public class Main {
     return new Authenticator(credentials, protectedUris, AUTH_ROUTE);
   }
 
-  private static Middleware configureMiddleware(Logger logger, Authenticator authenticator) {
-    Middleware middleware = logger;
-    middleware.linkWith(authenticator);
+  private static Middleware configureMiddleware(CorsMiddleware corsMiddleware, Logger logger, Authenticator authenticator) {
+    Middleware middleware = corsMiddleware;
+    middleware.linkWith(logger)
+              .linkWith(authenticator);
     return middleware;
   }
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,12 +1,8 @@
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
  
 public class Main {
+  private final static int DEFAULT_PORT_NUMBER = 8888;
   private final static String AUTH_ROUTE = "/api/authenticate";
-  private static final int DEFAULT_PORT_NUMBER = 8888;
-  private static final String LOG_DIRECTORY_PATH = System.getProperty("user.dir") + "/logs";
-  
   private static CLIParser parser;
   private static Directory directory;
  
@@ -19,10 +15,8 @@ public class Main {
  
       int port = parser.getPortNumberOrDefault(DEFAULT_PORT_NUMBER);
       Router router = setUpRouter(defaultHandler);
-      CorsMiddleware corsMiddleware = new CorsMiddleware();
-      Logger logger = setUpLogger();
-      Authenticator authenticator = setUpAuthenticator();
-      Middleware middleware = configureMiddleware(corsMiddleware, logger, authenticator);
+      Middleware middleware = new MiddlewareConfig().getMiddlewareChain();
+      
       Server server = new Server(port, router, middleware);
       server.start();
     } catch (ArrayIndexOutOfBoundsException e) {
@@ -72,28 +66,6 @@ public class Main {
     routes.put("/api/people", new PeopleHandler(directory));
     routes.put("/api/query", new QueryHandler(new UrlDecoder()));
     return routes;
-  }
-
-  private static Logger setUpLogger() throws LoggerException {
-    String dateTimePattern = "yyyymmddhhmmss";
-    Logger logger = new Logger(LOG_DIRECTORY_PATH, dateTimePattern);
-    logger.createLogFile();
-    return logger;
-  }
-
-  private static Authenticator setUpAuthenticator() {
-    Credentials credentials = new Credentials("username", "password");
-    List<String> protectedUris = Arrays.asList(
-      "/protected"
-    ); 
-    return new Authenticator(credentials, protectedUris, AUTH_ROUTE);
-  }
-
-  private static Middleware configureMiddleware(CorsMiddleware corsMiddleware, Logger logger, Authenticator authenticator) {
-    Middleware middleware = corsMiddleware;
-    middleware.linkWith(logger)
-              .linkWith(authenticator);
-    return middleware;
   }
 
 }

--- a/src/main/java/MessageHeader.java
+++ b/src/main/java/MessageHeader.java
@@ -1,6 +1,7 @@
 import java.io.UnsupportedEncodingException;
 
 public class MessageHeader {
+  public final static String AC_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
   public final static String ACCEPT_PATCH = "Accept-Patch";
   public final static String ALLOW = "Allow";
   public final static String AUTHENTICATE = "WWW-Authenticate";

--- a/src/main/java/Middleware/Middleware.java
+++ b/src/main/java/Middleware/Middleware.java
@@ -6,10 +6,12 @@ public abstract class Middleware {
     return next;
   }
 
-  public abstract Request applyMiddleware(Request request);
+  public Request applyMiddleware(Request request) {
+    return checkNext(request);
+  }
 
   public Response applyMiddleware(Response response) {
-    return response;
+    return checkNext(response);
   };
 
   protected Request checkNext(Request request) {

--- a/src/main/java/Middleware/MiddlewareConfig.java
+++ b/src/main/java/Middleware/MiddlewareConfig.java
@@ -1,0 +1,34 @@
+import java.util.Arrays;
+import java.util.List;
+
+public class MiddlewareConfig {
+  private final static String AUTH_ROUTE = "/api/authenticate";
+  private static final String LOG_DIRECTORY_PATH = System.getProperty("user.dir") + "/logs";
+
+  public Middleware getMiddlewareChain() throws LoggerException {
+    CorsMiddleware corsMiddleware = new CorsMiddleware();
+    Logger logger = setUpLogger();
+    Authenticator authenticator = setUpAuthenticator();
+
+    Middleware middleware = corsMiddleware;
+    middleware.linkWith(logger)
+              .linkWith(authenticator);
+    return middleware;
+  }
+
+  private Logger setUpLogger() throws LoggerException {
+      String dateTimePattern = "yyyymmddhhmmss";
+      Logger logger = new Logger(LOG_DIRECTORY_PATH, dateTimePattern);
+      logger.createLogFile();
+      return logger;
+  }
+
+  private Authenticator setUpAuthenticator() {
+    Credentials credentials = new Credentials("username", "password");
+    List<String> protectedUris = Arrays.asList(
+      "/protected"
+    ); 
+    return new Authenticator(credentials, protectedUris, AUTH_ROUTE);
+  }
+  
+}

--- a/src/test/java/CorsMiddlewareTest.java
+++ b/src/test/java/CorsMiddlewareTest.java
@@ -1,0 +1,35 @@
+import java.util.HashMap;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class CorsMiddlewareTest {
+  private final static String HEADER_FIELD = "a-header-field";
+  private final static String HEADER_VALUE = "a-header-value";
+  private final static HashMap<String, String> ORIGINAL_HEADERS = createOriginalHeaders();
+ 
+  @Test
+  public void test() {
+    CorsMiddleware corsMiddleware = new CorsMiddleware();
+    Response originalResponse = new Response.Builder(HttpStatusCode.OK)
+                                            .headers(ORIGINAL_HEADERS)
+                                            .build();
+    Response updatedResponse = corsMiddleware.applyMiddleware(originalResponse);
+    
+    HashMap<String, String> expectedHeaders = createExpectedHeaders();
+    HashMap<String, String> actualHeaders = updatedResponse.getHeaders();
+    assertEquals(expectedHeaders, actualHeaders);
+  }
+
+  private static HashMap<String, String> createOriginalHeaders() {
+    HashMap<String, String> headers = new HashMap<String, String>();
+    headers.put(HEADER_FIELD, HEADER_VALUE);
+    return headers;
+  }
+
+  private HashMap<String, String> createExpectedHeaders() {
+    HashMap<String, String> headers = ORIGINAL_HEADERS;
+    headers.put(MessageHeader.AC_ALLOW_ORIGIN, "*");     
+    return headers;
+  }
+  
+}

--- a/src/test/java/Handler/FileHandlerTest.java
+++ b/src/test/java/Handler/FileHandlerTest.java
@@ -42,13 +42,6 @@ public class FileHandlerTest {
   }
   
   @Test 
-  public void returnsSupportedMethodsInAllowHeaderForOptionsRequestToPatchableResource() {
-    String expectedHeaderVal = "DELETE, GET, HEAD, OPTIONS, PATCH, PUT";
-    String actualHeaderVal = responseToOptions.getHeader(MessageHeader.ALLOW);
-    assertEquals(expectedHeaderVal, actualHeaderVal);
-  }
-
-  @Test 
   public void returnsSupportedMethodsInAllowHeaderForOptionsRequestToNonPatchableResource() {
     responseToOptions = fileHandler.generateResponse(TestUtil.buildRequestToUri(HttpMethod.OPTIONS, IMAGE_FILE_URI));
     String expectedHeaderVal = "DELETE, GET, HEAD, OPTIONS";

--- a/src/test/resources/features/cors.feature
+++ b/src/test/resources/features/cors.feature
@@ -1,0 +1,12 @@
+Feature: Cross Origin Resource Sharing 
+
+Scenario Outline: GET request to a resource
+  When a client makes a GET request to <Path>
+  Then the server should respond with status code 200 OK 
+  And the server should respond with the header Access-Control-Allow-Origin *
+
+  Examples: 
+  |  Path              | 
+  | /cat-and-dog.jpg   |
+  | /sample.txt        | 
+  | /sample.json       | 

--- a/src/test/resources/features/optionsRequest.feature
+++ b/src/test/resources/features/optionsRequest.feature
@@ -35,7 +35,7 @@ Scenario Outline: OPTIONS request to files
   Examples: Existing files
   | File Name   | Directory |  Path        | Supported Methods |
   | sample.json | /         | /sample.json | DELETE, GET, HEAD, OPTIONS, PATCH, PUT | 
-  | sample.txt  | /         | /sample.txt  | DELETE, GET, HEAD, OPTIONS, PATCH, PUT | 
+  | sample.txt  | /         | /sample.txt  | DELETE, GET, HEAD, OPTIONS, PUT | 
 
 Scenario Outline: OPTIONS request to nonexistent files
   Given a file with the name <File Name> does not exist in <Directory>


### PR DESCRIPTION
## CorsMiddleware
In order to centralize the logic for returning the correct CORS headers (of which only `Access-Control-Allow-Origin` is supported), I created this class as an extension of `Middleware`. As with the other `Middleware` implementations, `CorsMiddleware` builds and returns a new instance of `Response`. It extracts the original `Response`'s headers and adds the `Access-Control-Allow-Origin` header/field to the new `Response`. 

Currently, an instance of `CorsMiddleware` is created with an empty constructor. For further configuration, I could pass in allowed origins, headers, max-age, credentials, and methods. If enough of those parameters would have to be passed in, it would likely make sense to create an `AccessControl` class to pass in as a single parameter to the `CorsMiddleware` class. 

## MiddlewareConfig 
I've removed the logic for creating and configuring each piece of `Middleware` (`Authenticator`, `Logger`, and `CorsMiddleware`) out of the `Main` class and into the `MiddlewareConfig` class. 

## `cors.feature`
Unfortunately, I have not been able to test this feature the way I originally intended to do so. I was hoping to run a second server on a different port and serving a different directory. That other directory would contain numerous resources. The original file would contain an HTML file with a script containing an AJAX request to GET the resource in the other server. While this approach worked on the browser, the `HTTPURLConnection` class only receives the raw HTML in the message body. This means that after the initial GET request to the resource on the main server, it does not follow up with a GET request to the resource on the other server. It's not clear that the [Apache HTTPClient class](https://hc.apache.org/httpcomponents-client-ga/) would work any differently.

For this reason, my Cucumber tests simply test that the response returns the correct field and value for the `Access-Control-Allow-Origin` header. 
